### PR TITLE
Fix all categories shown for each visual group

### DIFF
--- a/component/frontend/views/latests/tmpl/generic.php
+++ b/component/frontend/views/latests/tmpl/generic.php
@@ -38,6 +38,7 @@ defined('_JEXEC') or die();
 		<?php endif; ?>
 
 		<?php foreach($this->items[$renderSection] as $id => $item): ?>
+		<?php if($item->vgroup_id != $vgroupID) continue;?>
 		<?php if (!empty($item->release) && !empty($item->release->files)): ?>
 		<?php echo $this->loadAnyTemplate('site:com_ars/latest/category', array('id' => $id, 'item' => $item, 'Itemid' => $this->Itemid)); ?>
 		<?php endif; ?>


### PR DESCRIPTION
Lost in the commit to bootstrap the latest view. Currently all categories are shown for each visual group. This commit fixes this issue and only the categories for the specific visual group are shown.
