### PR TITLE
Fixing wrong vgroupID keys that result in display issues

### DIFF
--- a/component/frontend/views/browses/tmpl/generic.php
+++ b/component/frontend/views/browses/tmpl/generic.php
@@ -21,24 +21,24 @@ defined('_JEXEC') or die();
 		<?php echo JText::_('ARS_NO_CATEGORIES'); ?>
 	</p>
 	<?php else:?>
-	<?php foreach($this->vgroups as $vgroupID => $vgroup): ?>
+	<?php foreach($this->vgroups as $vgroup): ?>
 	<?php if ($vgroup->numitems[$renderSection] == 0) {
 		continue;
 	} ?>
-	<div class="ars-vgroup-<?php $vgroupID ?>">
+	<div class="ars-vgroup-<?php $vgroup->id ?>">
 		<?php if($vgroup->title): ?>
-		<h3 class="ars-vgroup-<?php $vgroupID ?>-title">
+		<h3 class="ars-vgroup-<?php $vgroup->id ?>-title">
 			<?php echo $vgroup->title; ?>
 		</h3>
 		<?php if ($vgroup->description): ?>
-		<div class="ars-vgroup-<?php $vgroupID ?>-description">
+		<div class="ars-vgroup-<?php $vgroup->id ?>-description">
 			<?php echo $vgroup->description; ?>
 		</div>
 		<?php endif; ?>
 		<?php endif; ?>
 
 		<?php foreach($this->items[$renderSection] as $id => $item): ?>
-		<?php if($item->vgroup_id != $vgroupID) continue;?>
+		<?php if($item->vgroup_id != $vgroup->id) continue;?>
 		<?php echo $this->loadAnyTemplate('site:com_ars/browses/category', array('id' => $id, 'item' => $item, 'Itemid' => $this->Itemid)); ?>
 		<?php endforeach; ?>
 	</div>

--- a/component/frontend/views/browses/view.html.php
+++ b/component/frontend/views/browses/view.html.php
@@ -34,6 +34,7 @@ class ArsViewBrowses extends FOFViewHtml
 		$groupedItems = 0;
 
 		$defaultVgroup = (object)array(
+			'id'			=> '',
 			'title'			=> '',
 			'description'	=> '',
 			'numitems'		=> array(),
@@ -73,6 +74,7 @@ class ArsViewBrowses extends FOFViewHtml
 				}
 
 				$vgroups[$r->id] = (object)array(
+					'id'			=> $r->id,
 					'title'			=> $r->title,
 					'description'	=> $r->description,
 					'numitems'		=> $noOfItems,

--- a/component/frontend/views/latests/tmpl/generic.php
+++ b/component/frontend/views/latests/tmpl/generic.php
@@ -21,24 +21,24 @@ defined('_JEXEC') or die();
 		<?php echo JText::_('ARS_NO_CATEGORIES'); ?>
 	</p>
 	<?php else:?>
-	<?php foreach($this->vgroups as $vgroupID => $vgroup): ?>
+	<?php foreach($this->vgroups as $vgroup): ?>
 	<?php if ($vgroup->numitems[$renderSection] == 0) {
 		continue;
 	} ?>
-	<div class="ars-vgroup-<?php $vgroupID ?>">
+	<div class="ars-vgroup-<?php $vgroup->id ?>">
 		<?php if($vgroup->title): ?>
-		<h3 class="ars-vgroup-<?php $vgroupID ?>-title">
+		<h3 class="ars-vgroup-<?php $vgroup->id ?>-title">
 			<?php echo $vgroup->title; ?>
 		</h3>
 		<?php if ($vgroup->description): ?>
-		<div class="ars-vgroup-<?php $vgroupID ?>-description">
+		<div class="ars-vgroup-<?php $vgroup->id ?>-description">
 			<?php echo $vgroup->description; ?>
 		</div>
 		<?php endif; ?>
 		<?php endif; ?>
 
 		<?php foreach($this->items[$renderSection] as $id => $item): ?>
-		<?php if($item->vgroup_id != $vgroupID) continue;?>
+		<?php if($item->vgroup_id != $vgroup->id) continue;?>
 		<?php if (!empty($item->release) && !empty($item->release->files)): ?>
 		<?php echo $this->loadAnyTemplate('site:com_ars/latest/category', array('id' => $id, 'item' => $item, 'Itemid' => $this->Itemid)); ?>
 		<?php endif; ?>

--- a/component/frontend/views/latests/view.html.php
+++ b/component/frontend/views/latests/view.html.php
@@ -35,6 +35,7 @@ class ArsViewLatests extends FOFViewHtml
 		$groupedItems = 0;
 
 		$defaultVgroup = (object)array(
+			'id'			=> '',
 			'title'			=> '',
 			'description'	=> '',
 			'numitems'		=> array()
@@ -80,6 +81,7 @@ class ArsViewLatests extends FOFViewHtml
 				}
 
 				$vgroups[$r->id] = (object)array(
+					'id'			=> $r->id,
 					'title'			=> $r->title,
 					'description'	=> $r->description,
 					'numitems'		=> $noOfItems,


### PR DESCRIPTION
The $vgroupID => $vgroup is causing issue as the key is not the same as the vgroup ID, this is caused by the vgroups array_merge in the view.html.php file.
