### PR TITLE
Test if GeoIp plugin is enabled

### DIFF
--- a/component/backend/models/cpanels.php
+++ b/component/backend/models/cpanels.php
@@ -277,7 +277,8 @@ class ArsModelCpanels extends FOFModel
 			->from($db->qn('#__extensions'))
 			->where($db->qn('type') . ' = ' . $db->q('plugin'))
 			->where($db->qn('folder') . ' = ' . $db->q('system'))
-			->where($db->qn('element') . ' = ' . $db->q('akgeoip'));
+			->where($db->qn('element') . ' = ' . $db->q('akgeoip'))
+			->where($db->qn('enabled') . ' = 1');
 		$db->setQuery($query);
 		$result = $db->loadResult();
 


### PR DESCRIPTION
Updating the DB gives a fatal error if plugin isn't published:
`Fatal error: Class 'AkeebaGeoipProvider' not found in /.../administrator/components/com_ars/controllers/cpanel.php on line 35`
