### PR TITLE
Fix empty item_id logging

### DIFF
--- a/component/frontend/controllers/download.php
+++ b/component/frontend/controllers/download.php
@@ -97,7 +97,11 @@ class ArsControllerDownload extends FOFController
 		}
 
 		$item->hit();
-		$log->save(array('authorized' => 1));
+		$log->save(array(
+			'item_id' => $id,
+			'authorized' => 1
+			)
+		);
 
 		$model->doDownload();
 

--- a/component/frontend/controllers/update.php
+++ b/component/frontend/controllers/update.php
@@ -268,11 +268,14 @@ class ArsControllerUpdate extends FOFController
 		}
 
 		$item->hit();
-		$log->save(array('authorized' => 1));
+		$log->save(array(
+			'item_id' => $dlitem->item_id,
+			'authorized' => 1
+			)
+		);
 
 		$dl_model->doDownload();
 
 		// No need to return anything; doDownload() calls the exit() method of the application object
 	}
-
 }


### PR DESCRIPTION
Happened at least with arslatest plugin

-edit-
Clarification: the item at the logs view was empty. item_id was 1, which was not the correct value.
