### PR TITLE
# [LOW] Fixed page headings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Version 2.3.3
 ~ Only show a reminder to update the GeoIP database if it's older than two weeks
 # [MEDIUM] Wrong link for GeoIP update
 # [MEDIUM] Download link in update stream always appends &dummy=my.zip (thanks Francesco & Hayden)
+# [LOW] Fixed page headings
 
 Version 2.3.2
 ================================================================================

--- a/component/frontend/views/browses/tmpl/bleedingedge.php
+++ b/component/frontend/views/browses/tmpl/bleedingedge.php
@@ -7,12 +7,16 @@
 
 defined('_JEXEC') or die();
 
+$app = JFactory::getApplication();
+$menus = $app->getMenu();
+$menu = $menus->getActive();
+
 ?>
 <div class="item-page<?php echo $this->params->get('pageclass_sfx') ?>">
-	<?php if ($this->params->get('show_page_heading') && $this->params->get('show_title')) : ?>
-	<div class="page-header">
-		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
-	</div>
+	<?php if ($this->params->get('show_page_heading')) : ?>
+		<div class="page-header">
+			<h1><?php echo $this->escape($this->params->get('page_heading', $menu->title)); ?></h1>
+		</div>
 	<?php endif;?>
 	<?php echo $this->loadAnyTemplate('site:com_ars/browses/generic', array('renderSection' => 'bleedingedge', 'title' => 'ARS_CATEGORY_BLEEDINGEDGE')); ?>
 </div>

--- a/component/frontend/views/browses/tmpl/normal.php
+++ b/component/frontend/views/browses/tmpl/normal.php
@@ -7,12 +7,16 @@
 
 defined('_JEXEC') or die();
 
+$app = JFactory::getApplication();
+$menus = $app->getMenu();
+$menu = $menus->getActive();
+
 ?>
 <div class="item-page<?php echo $this->params->get('pageclass_sfx') ?>">
-	<?php if ($this->params->get('show_page_heading') && $this->params->get('show_title')) : ?>
-	<div class="page-header">
-		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
-	</div>
+	<?php if ($this->params->get('show_page_heading')) : ?>
+		<div class="page-header">
+			<h1><?php echo $this->escape($this->params->get('page_heading', $menu->title)); ?></h1>
+		</div>
 	<?php endif;?>
 	<?php echo $this->loadAnyTemplate('site:com_ars/browses/generic', array('renderSection' => 'normal', 'title' => 'ARS_CATEGORY_NORMAL')); ?>
 </div>

--- a/component/frontend/views/browses/tmpl/repository.php
+++ b/component/frontend/views/browses/tmpl/repository.php
@@ -7,12 +7,16 @@
 
 defined('_JEXEC') or die();
 
+$app = JFactory::getApplication();
+$menus = $app->getMenu();
+$menu = $menus->getActive();
+
 ?>
 <div class="item-page<?php echo $this->params->get('pageclass_sfx') ?>">
-	<?php if ($this->params->get('show_page_heading') && $this->params->get('show_title')) : ?>
-	<div class="page-header">
-		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
-	</div>
+	<?php if ($this->params->get('show_page_heading')) : ?>
+		<div class="page-header">
+			<h1><?php echo $this->escape($this->params->get('page_heading', $menu->title)); ?></h1>
+		</div>
 	<?php endif;?>
 
 <?php if( array_key_exists('all', $this->items) ): ?>

--- a/component/frontend/views/category/tmpl/default.php
+++ b/component/frontend/views/category/tmpl/default.php
@@ -7,13 +7,16 @@
 
 defined('_JEXEC') or die();
 
-?>
+$app = JFactory::getApplication();
+$menus = $app->getMenu();
+$menu = $menus->getActive();
 
+?>
 <div class="item-page<?php echo $this->pparams->get('pageclass_sfx') ?>">
-	<?php if ($this->pparams->get('show_page_heading') && $this->pparams->get('show_title')) : ?>
-	<div class="page-header">
-		<h1> <?php echo $this->escape($this->pparams->get('page_heading')); ?> </h1>
-	</div>
+	<?php if ($this->pparams->get('show_page_heading')) : ?>
+		<div class="page-header">
+			<h1><?php echo $this->escape($this->pparams->get('page_heading', $menu->title)); ?></h1>
+		</div>
 	<?php endif;?>
 
 	<?php echo $this->loadAnyTemplate('site:com_ars/browses/category', array('id' => $this->item->id, 'item' => $this->item, 'Itemid' => $this->Itemid, 'no_link' => true)); ?>

--- a/component/frontend/views/dlidlabels/tmpl/default.php
+++ b/component/frontend/views/dlidlabels/tmpl/default.php
@@ -10,11 +10,15 @@ defined('_JEXEC') or die();
 JHtml::_('behavior.framework');
 
 $this->loadHelper('filter');
-?>
 
+$app = JFactory::getApplication();
+$menus = $app->getMenu();
+$menu = $menus->getActive();
+
+?>
 <?php if ($this->params->get('show_page_heading')) : ?>
 	<div class="page-header">
-		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
+		<h1><?php echo $this->escape($this->params->get('page_heading', $menu->title)); ?></h1>
 	</div>
 <?php endif;?>
 

--- a/component/frontend/views/latests/tmpl/latest.php
+++ b/component/frontend/views/latests/tmpl/latest.php
@@ -7,13 +7,17 @@
 
 defined('_JEXEC') or die();
 
+$app = JFactory::getApplication();
+$menus = $app->getMenu();
+$menu = $menus->getActive();
+
 ?>
 <div class="item-page<?php echo $this->cparams->get('pageclass_sfx') ?>">
 
 <?php if ($this->cparams->get('show_page_heading', 1)): ?>
 	<div class="page-header">
 		<h1>
-			<?php echo $this->escape($this->cparams->get('page_heading')); ?>
+			<?php echo $this->escape($this->cparams->get('page_heading', $menu->title)); ?>
 		</h1>
 	</div>
 <?php elseif (!$this->cparams->get('show_page_heading', 1)): ?>

--- a/component/frontend/views/release/tmpl/default.php
+++ b/component/frontend/views/release/tmpl/default.php
@@ -15,13 +15,18 @@ $this->item->hit();
 $results    = false;
 $released   = new JDate($this->item->created);
 $userAccess = JFactory::getUser()->getAuthorisedViewLevels();
-?>
 
+$app = JFactory::getApplication();
+$menus = $app->getMenu();
+$menu = $menus->getActive();
+$pageHeading = $this->pparams->get('page_heading', $menu->title) . ' ' . $this->item->version;
+
+?>
 <div class="item-page<?php echo $this->pparams->get('pageclass_sfx') ?>">
-	<?php if ($this->pparams->get('show_page_heading') && $this->pparams->get('show_title')) : ?>
-	<div class="page-header">
-		<h1> <?php echo $this->escape($this->pparams->get('page_heading')); ?> </h1>
-	</div>
+	<?php if ($this->pparams->get('show_page_heading')) : ?>
+		<div class="page-header">
+			<h1><?php echo $this->escape($pageHeading); ?></h1>
+		</div>
 	<?php endif;?>
 
 	<?php echo $this->loadAnyTemplate('site:com_ars/category/release', array('item' => $this->item, 'Itemid' => $this->Itemid, 'no_link' => true)); ?>


### PR DESCRIPTION
Hi Nicholas,

I've fixed/added the page headings (show_title is not used in com_ars, only in com_content). I also used the active menu title as a fallback.

The only heading which might require your attention is the one of component/frontend/views/release/tmpl/default.php. But I think this is the nicest solution. 

Live 'demo': https://www.twentronix.com/downloads

Kind regards,
Jurian Even
