### PR TITLE
# [MEDIUM] Blank page or 400 error message after updating from 2.3.2 or lower using Live Update

### DIFF
--- a/component/backend/dispatcher.php
+++ b/component/backend/dispatcher.php
@@ -26,15 +26,6 @@ class ArsDispatcher extends FOFDispatcher
 			return $result;
 		}
 
-		$view = FOFInflector::singularize($this->input->getCmd('view',$this->defaultView));
-
-		if ($view == 'liveupdate')
-		{
-			$url = JUri::base() . 'index.php?option=com_ars';
-			JFactory::getApplication()->redirect($url);
-			return;
-		}
-
 		// Load Akeeba Strapper
 		include_once JPATH_ROOT . '/media/akeeba_strapper/strapper.php';
 		AkeebaStrapper::bootstrap();


### PR DESCRIPTION
Hi Nicholas,

The previous fix (https://github.com/akeeba/release-system/commit/a2c9d69fdc7aefcb3e0bcd4ef97fec20081ccd24) didn't work when I tested it with my extension. I thought there wasn't a neat solution, but I've found one! :dancers: This fix works and I've tested it with Joomla 3.2.3 and a modified version of liveupdate for ARS (I obviously can't test with your server). Also I did some tests with one of my own components.

Btw I really recommend to implement a common installer (like I do with Twentronix Installer), it will really save you a lot of work. 

Kind regards,
Jurian Even
