### PR TITLE
~ Also show release notes at release view

### DIFF
--- a/component/frontend/views/category/tmpl/release.php
+++ b/component/frontend/views/category/tmpl/release.php
@@ -52,8 +52,6 @@ switch ($item->maturity)
 		</a>
 	</h4>
 
-	<?php if(!isset($no_link)): ?>
-
 	<dl class="dl-horizontal ars-release-properties">
 		<dt>
 			<?php echo JText::_('COM_ARS_RELEASES_FIELD_MATURITY') ?>:
@@ -70,46 +68,44 @@ switch ($item->maturity)
 		</dd>
 
 		<?php if($this->pparams->get('show_downloads', 1)): ?>
-		<dt>
-			<?php echo JText::_('LBL_RELEASES_HITS') ?>:
-		</dt>
-		<dd>
-			<?php echo JText::sprintf( ($item->hits == 1 ? 'LBL_RELEASES_TIME' : 'LBL_RELEASES_TIMES'), $item->hits) ?>
-		</dd>
+			<dt>
+				<?php echo JText::_('LBL_RELEASES_HITS') ?>:
+			</dt>
+			<dd>
+				<?php echo JText::sprintf( ($item->hits == 1 ? 'LBL_RELEASES_TIME' : 'LBL_RELEASES_TIMES'), $item->hits) ?>
+			</dd>
 		<?php endif; ?>
 	</dl>
 
 	<?php if(version_compare(JVERSION, '3.0', 'lt')): ?>
-	<?php echo $tabs->startPane('reltabs-'.$item->id); ?>
+		<?php echo $tabs->startPane('reltabs-'.$item->id); ?>
 		<?php echo $tabs->startPanel(JText::_('COM_ARS_RELEASE_DESCRIPTION_LABEL'),'reltabs-'.$item->id.'-desc') ?>
-			<?php echo ArsHelperHtml::preProcessMessage($item->description, 'com_ars.release_description'); ?>
+		<?php echo ArsHelperHtml::preProcessMessage($item->description, 'com_ars.release_description'); ?>
 		<?php echo $tabs->endPanel(); ?>
 		<?php echo $tabs->startPanel(JText::_('COM_ARS_RELEASE_NOTES_LABEL'),'reltabs-'.$item->id.'-notes') ?>
-			<?php echo ArsHelperHtml::preProcessMessage($item->notes, 'com_ars.release_notes') ?>
+		<?php echo ArsHelperHtml::preProcessMessage($item->notes, 'com_ars.release_notes') ?>
 		<?php echo $tabs->endPanel(); ?>
-	<?php echo $tabs->endPane(); ?>
+		<?php echo $tabs->endPane(); ?>
 	<?php else: ?>
-	<ul class="nav nav-tabs">
-		<li class="active"><a href="#reltabs-<?php echo $item->id ?>-desc" data-toggle="tab"><?php echo JText::_('COM_ARS_RELEASE_DESCRIPTION_LABEL') ?></a>
-		<li><a href="#reltabs-<?php echo $item->id ?>-notes" data-toggle="tab"><?php echo JText::_('COM_ARS_RELEASE_NOTES_LABEL') ?></a>
-	</ul>
-	<div class="tab-content">
-		<div class="tab-pane active" id="reltabs-<?php echo $item->id ?>-desc">
-			<?php echo ArsHelperHtml::preProcessMessage($item->description, 'com_ars.release_description'); ?>
+		<ul class="nav nav-tabs">
+			<li class="active"><a href="#reltabs-<?php echo $item->id ?>-desc" data-toggle="tab"><?php echo JText::_('COM_ARS_RELEASE_DESCRIPTION_LABEL') ?></a>
+			<li><a href="#reltabs-<?php echo $item->id ?>-notes" data-toggle="tab"><?php echo JText::_('COM_ARS_RELEASE_NOTES_LABEL') ?></a>
+		</ul>
+		<div class="tab-content">
+			<div class="tab-pane active" id="reltabs-<?php echo $item->id ?>-desc">
+				<?php echo ArsHelperHtml::preProcessMessage($item->description, 'com_ars.release_description'); ?>
+			</div>
+			<div class="tab-pane" id="reltabs-<?php echo $item->id ?>-notes">
+				<?php echo ArsHelperHtml::preProcessMessage($item->notes, 'com_ars.release_notes'); ?>
+			</div>
 		</div>
-		<div class="tab-pane" id="reltabs-<?php echo $item->id ?>-notes">
-			 <?php echo ArsHelperHtml::preProcessMessage($item->notes, 'com_ars.release_notes'); ?>
-		</div>
-	</div>
 	<?php endif; ?>
 
-	<p class="readmore">
-		<a href="<?php echo htmlentities($release_url); ?>" class="btn btn-primary">
-			<?php echo JText::_('LBL_RELEASE_VIEWITEMS') ?>
-		</a>
-	</p>
-
-	<?php else: ?>
-	<?php echo ArsHelperHtml::preProcessMessage($item->description, 'com_ars.release_description'); ?>
+	<?php if(!isset($no_link) || !$no_link): ?>
+		<p class="readmore">
+			<a href="<?php echo htmlentities($release_url); ?>" class="btn btn-primary">
+				<?php echo JText::_('LBL_RELEASE_VIEWITEMS') ?>
+			</a>
+		</p>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
# [LOW] When $no_link is false it's still shown (isset(false)) returns true)

The read more button of the component's Joomla update feature links to the release item. When the release notes are not shown, users won't be aware of them.
