### PR TITLE
Prevent outputting JUpdater notices and other possible junk

### DIFF
--- a/component/backend/controllers/cpanel.php
+++ b/component/backend/controllers/cpanel.php
@@ -98,7 +98,7 @@ class ArsControllerCpanel extends F0FController
 ENDRESULT;
 		}
 
-		echo $result;
+		echo '###' . $result . '###';
 
 		// Cut the execution short
 		JFactory::getApplication()->close();

--- a/component/backend/views/cpanels/tmpl/default.php
+++ b/component/backend/views/cpanels/tmpl/default.php
@@ -195,8 +195,12 @@ akeeba.jQuery(document).ready(function($){
 	});
 
 	$.ajax('index.php?option=com_ars&view=cpanel&task=updateinfo&tmpl=component', {
-		success: function(data, textStatus, jqXHR)
+		success: function(msg, textStatus, jqXHR)
 		{
+			// Get rid of junk before and after data
+			var match = msg.match(/###([\s\S]*?)###/);
+			data = match[1];
+
 			if (data.length)
 			{
 				$('#updateNotice').html(data);


### PR DESCRIPTION
I got JUpdater notices outputted before our data. This fixes it.
`[\s\S]*` is btw the Javascript `.*` modifier which also matches new lines.

When finding updates at our Cpanel, JUdpater btw fetches _all_ updates of the update sites. But that's a different story and probably not fixable by our code. It's not such a big deal.
