### PR TITLE
First load the latest F0F version at the installation script

### DIFF
--- a/component/script.ars.php
+++ b/component/script.ars.php
@@ -11,8 +11,8 @@ defined('_JEXEC') or die();
 if (!defined('F0F_INCLUDED'))
 {
 	$paths = array(
-		(defined('JPATH_LIBRARIES') ? JPATH_LIBRARIES : JPATH_ROOT . '/libraries') . '/f0f/include.php',
 		__DIR__ . '/fof/include.php',
+		(defined('JPATH_LIBRARIES') ? JPATH_LIBRARIES : JPATH_ROOT . '/libraries') . '/f0f/include.php',
 	);
 
 	foreach ($paths as $filePath)


### PR DESCRIPTION
Hello Nicholas,

If you have F0F installed which doesn't yet have F0FDatabaseInstaller and you install an extension which uses F0FDatabaseInstaller, you'll get the error `Fatal error: Class 'F0FDatabaseInstaller' not found`.

This is because of the loading order of F0F:

```
// Load FOF if not already loaded
if (!defined('F0F_INCLUDED'))
{
    $paths = array(
        (defined('JPATH_LIBRARIES') ? JPATH_LIBRARIES : JPATH_ROOT . '/libraries') . '/f0f/include.php',
        __DIR__ . '/fof/include.php',
    );

    foreach ($paths as $filePath)
    {
        if (!defined('F0F_INCLUDED') && file_exists($filePath))
        {
            @include_once $filePath;
        }
    }
}
```

The older installed F0F version is loaded if available. The newer shipped F0F version is only used when the site's F0F library is unavailable. This example only explains the issue with F0FDatabaseInstaller, but this of course holds for all newer F0F code which is not available at the F0F library of the installed site. 

This PR fixes this.

Best regards,
Jurian Even
