### PR TITLE
# [MEDIUM] Updating the GeoIP database throw a fatal error when the GeoIP library has not been loaded

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Version 2.3.4
 ~ Significant performance improvement in the Latest Releases content plugin when using Akeeba Subscriptions
 # [MEDIUM] Blank page or 400 error message after updating from 2.3.2 or lower using Live Update
 # [MEDIUM] Bleeding edge releases with dots/spaces in the folder gave a 404 error
+# [MEDIUM] Updating the GeoIP database throw a fatal error when the GeoIP library has not been loaded
 # [LOW] Searching by title in Automatic Item Descriptions leads to a SQL error
 
 Version 2.3.3

--- a/component/backend/controllers/cpanel.php
+++ b/component/backend/controllers/cpanel.php
@@ -32,6 +32,18 @@ class ArsControllerCpanel extends F0FController
 			$this->_csrfProtection();
 		}
 
+		// Load the GeoIP library if it's not already loaded
+		if (!class_exists('AkeebaGeoipProvider'))
+		{
+			if (@file_exists(JPATH_PLUGINS . '/system/akgeoip/lib/akgeoip.php'))
+			{
+				if (@include_once JPATH_PLUGINS . '/system/akgeoip/lib/vendor/autoload.php')
+				{
+					@include_once JPATH_PLUGINS . '/system/akgeoip/lib/akgeoip.php';
+				}
+			}
+		}
+
 		$geoip = new AkeebaGeoipProvider();
 		$result = $geoip->updateDatabase();
 


### PR DESCRIPTION
We didn't detect this error because the System - Admin Tools plugin loads the library. You can replicate this error by disabling that plugin and try to update the GeoIP database. You will get the error: "Fatal error: Class 'AkeebaGeoipProvider' not found".

Make sure to also implement this fix in `updategeoip()` of your other extensions.
