### PR TITLE
BleedingEdge cats using _BETA syntax not recognized

### DIFF
--- a/component/frontend/models/bleedingedge.php
+++ b/component/frontend/models/bleedingedge.php
@@ -100,8 +100,8 @@ class ArsModelBleedingedge extends F0FModel
 		{
 			foreach($allReleases as $release)
 			{
-				$folder = $this->folder.'/'.$release->version;
-				$known_folders[] = $release->version;
+				$folder = $this->folder.'/'.$release->alias;
+				$known_folders[] = $release->alias;
 
 				if(!$release->published) continue;
 
@@ -276,7 +276,7 @@ class ArsModelBleedingedge extends F0FModel
 		}
 		if($this->category->type != 'bleedingedge') return;
 
-		$folder = $this->folder.'/'.$release->version;
+		$folder = $this->folder.'/'.$release->alias;
 
 		$potentialPrefix = substr($folder, 0, 5);
 		$potentialPrefix = strtolower($potentialPrefix);
@@ -363,7 +363,7 @@ class ArsModelBleedingedge extends F0FModel
 				'release_id'		=> $release->id,
 				'description'		=> '',
 				'type'				=> 'file',
-				'filename'			=> $release->version.'/'.$file,
+				'filename'			=> $release->alias.'/'.$file,
 				'url'				=> '',
 				'groups'			=> $release->groups,
 				'hits'				=> '0',


### PR DESCRIPTION
References:
- https://github.com/akeeba/release-system/commit/afe3be028f40eae9ecd67b8688eef9d6ea9e18e6
- https://www.akeebabackup.com/support/akeeba-release-system/20032-path-is-not-a-folder-error-with-bleedingedge-categories.html#p111556
