### PR TITLE
Fix for compatibility with PayPlans 3.x

### DIFF
--- a/component/backend/helpers/filtering.php
+++ b/component/backend/helpers/filtering.php
@@ -180,7 +180,8 @@ class ArsHelperFiltering
 
 				case 'payplans':
 					$status = PayplansStatus::SUBSCRIPTION_ACTIVE;
-					$userGroups[$user_id] = PayplansApi::getUser($user_id)->getSubscriptions($status);
+					// For PayPlans 3.x
+					$userGroups[$user_id] = PayplansApi::getUser($user_id)->getPlans($status);
 					break;
 
 				default:


### PR DESCRIPTION
ARS doesn't work correctly with PayPlans 3.x. This fix solves the problem.

More in detail, the call to 'PayplansApi::getUser($user_id)->getSubscriptions($status)' gives an array of objects with the subscriptions details for the user while 'PayplansApi::getUser($user_id)->getPlans($status)' returns an array of plans ids.
