### PR TITLE
Update en-GB.com_ars.ini

### DIFF
--- a/translations/component/backend/en-GB/en-GB.com_ars.ini
+++ b/translations/component/backend/en-GB/en-GB.com_ars.ini
@@ -281,7 +281,7 @@ LBL_UPDATESTREAMS_LINKS="Links"
 LBL_UPDATESTREAMS_ALLLINKS_INTRO="Looking for a way to provide updates to all of your extensions at once? Just use the "
 LBL_UPDATESTREAMS_ALLLINKS="Master Joomla! 1.6 XML Update stream"
 
-COM_ARS_LBL_UPDATESTREAMS_SAVED="Update Stream saved successfully"
+COM_ARS_LBL_UPDATESTREAM_SAVED="Update Stream saved successfully"
 LBL_UPDATESTREAMS_DELETED="Update Stream(s) deleted successfully"
 LBL_UPDATESTREAMS_COPIED="Update Stream(s) copied successfully"
 


### PR DESCRIPTION
After saving an update stream I now see the message: COM_ARS_LBL_UPDATESTREAM_SAVED instead of the regular text. Hereby the language file update.
