### PR TITLE
Add logic to routing for visual group based menus

### DIFF
--- a/component/frontend/models/browses.php
+++ b/component/frontend/models/browses.php
@@ -79,7 +79,9 @@ class ArsModelBrowses extends F0FModel
 		else
 		{
 			$params = $app->getPageParameters('com_ars');
-			$vgroup = $params->get('vgroupid', '');
+
+			// The vgroupid may be set as part of the request, prefer that and fall back to the params otherwise
+			$vgroup = $app->input->getUint('vgroupid', $params->get('vgroupid', ''));
 		}
 
 		if ($vgroup)

--- a/component/frontend/router.php
+++ b/component/frontend/router.php
@@ -103,8 +103,9 @@ function arsBuildRouteHtml(&$query)
 	$id = ArsRouterHelper::getAndPop($query, 'id');
 	$Itemid = ArsRouterHelper::getAndPop($query, 'Itemid');
 	$language = ArsRouterHelper::getAndPop($query, 'language', $currentlang);
+	$vgroupid = ArsRouterHelper::getAndPop($query, 'vgroupid');
 
-	$qoptions = array('option' => 'com_ars', 'view' => $view, 'task' => $task, 'layout' => $layout, 'id' => $id, 'language' => $language);
+	$qoptions = array('option' => 'com_ars', 'view' => $view, 'task' => $task, 'layout' => $layout, 'id' => $id, 'language' => $language, 'vgroupid' => $vgroupid);
 	switch ($view)
 	{
 		case 'dlidlabel':
@@ -224,6 +225,15 @@ function arsBuildRouteHtml(&$query)
 				$options = $qoptions;
 				unset($options['id']);
 				$params = array('catid' => $id);
+
+				// Does the category have a visual group?  If so, let's add that to the query options
+				$catVgroupId = $catModel->getItem($id)->vgroup_id;
+
+				if ($catVgroupId)
+				{
+					$options['vgroupid'] = $catVgroupId;
+				}
+
 				$menu = ArsRouterHelper::findMenu($options, $params);
 				$Itemid = empty($menu) ? null : $menu->id;
 
@@ -236,6 +246,13 @@ function arsBuildRouteHtml(&$query)
 				{
 					// Not found. Try fetching a browser menu item
 					$options = array('option' => 'com_ars', 'view' => 'browses', 'layout' => 'repository', 'language' => $language);
+
+					// Does the category have a visual group?  If so, let's add that to the query options
+					if ($catVgroupId)
+					{
+						$options['vgroupid'] = $catVgroupId;
+					}
+
 					$menu = ArsRouterHelper::findMenu($options);
 					$Itemid = empty($menu) ? null : $menu->id;
 					if (!empty($Itemid))
@@ -310,6 +327,15 @@ function arsBuildRouteHtml(&$query)
 				// Try to find a category menu item
 				$options = array('view' => 'category', 'option' => 'com_ars', 'language' => $language);
 				$params = array('catid' => $release->category_id);
+
+				// Does the category have a visual group?  If so, let's add that to the query options
+				$catVgroupId = $catModel->getItem($release->category_id)->vgroup_id;
+
+				if ($catVgroupId)
+				{
+					$options['vgroupid'] = $catVgroupId;
+				}
+
 				$menu = ArsRouterHelper::findMenu($options, $params);
 				if (!empty($menu))
 				{
@@ -321,6 +347,13 @@ function arsBuildRouteHtml(&$query)
 				{
 					// Nah. Let's find a browse menu item.
 					$options = array('view' => 'browses', 'option' => 'com_ars', 'language' => $language);
+
+					// Does the category have a visual group?  If so, let's add that to the query options
+					if ($catVgroupId)
+					{
+						$options['vgroupid'] = $catVgroupId;
+					}
+
 					$menu = ArsRouterHelper::findMenu($options);
 					if (!empty($menu))
 					{
@@ -397,6 +430,16 @@ function arsBuildRouteFeed(&$query)
 			{
 				$options = array('view' => 'category', 'option' => 'com_ars');
 				$params = array('catid' => $id);
+
+				// Does the category have a visual group?  If so, let's add that to the query options
+				$catModel = F0FModel::getTmpInstance('Categories', 'ArsModel');
+				$catVgroupId = $catModel->getItem($id)->vgroup_id;
+
+				if ($catVgroupId)
+				{
+					$options['vgroupid'] = $catVgroupId;
+				}
+
 				$menu = ArsRouterHelper::findMenu($options, $params);
 				if (!empty($menu))
 				{
@@ -407,6 +450,13 @@ function arsBuildRouteFeed(&$query)
 				{
 					// Nah. Let's find a browse menu item.
 					$options = array('view' => 'browses', 'option' => 'com_ars');
+
+					// Does the category have a visual group?  If so, let's add that to the query options
+					if ($catVgroupId)
+					{
+						$options['vgroupid'] = $catVgroupId;
+					}
+
 					$menu = ArsRouterHelper::findMenu($options);
 
 					$model = F0FModel::getTmpInstance('Categories', 'ArsModel');
@@ -448,8 +498,9 @@ function arsBuildRouteRaw(&$query)
 	$layout = ArsRouterHelper::getAndPop($query, 'layout');
 	$id = ArsRouterHelper::getAndPop($query, 'id');
 	$Itemid = ArsRouterHelper::getAndPop($query, 'Itemid');
+	$vgroupid = ArsRouterHelper::getAndPop($query, 'vgroupid');
 
-	$qoptions = array('option' => 'com_ars', 'view' => $view, 'task' => $task, 'layout' => $layout, 'id' => $id);
+	$qoptions = array('option' => 'com_ars', 'view' => $view, 'task' => $task, 'layout' => $layout, 'id' => $id, 'vgroupid' => $vgroupid);
 	$menus = JMenu::getInstance('site');
 
 	// Get download item info
@@ -520,6 +571,15 @@ function arsBuildRouteRaw(&$query)
 	{
 		$options = array('option' => 'com_ars', 'view' => 'release');
 		$params = array('relid' => $release->id);
+
+		// Does the category have a visual group?  If so, let's add that to the query options
+		$catVgroupId = $catModel->getItem($release->category_id)->vgroup_id;
+
+		if ($catVgroupId)
+		{
+			$options['vgroupid'] = $catVgroupId;
+		}
+
 		$menu = ArsRouterHelper::findMenu($options, $params);
 		if (is_object($menu))
 		{
@@ -530,6 +590,12 @@ function arsBuildRouteRaw(&$query)
 		{
 			$options = array('option' => 'com_ars', 'view' => 'category');
 			$params = array('catid' => $release->category_id);
+
+			if ($catVgroupId)
+			{
+				$options['vgroupid'] = $catVgroupId;
+			}
+
 			$menu = ArsRouterHelper::findMenu($options, $params);
 		}
 		if (is_object($menu))
@@ -541,6 +607,12 @@ function arsBuildRouteRaw(&$query)
 		if (!is_object($menu))
 		{
 			$options = array('view' => 'browses', 'option' => 'com_ars');
+
+			if ($catVgroupId)
+			{
+				$options['vgroupid'] = $catVgroupId;
+			}
+
 			$menu = ArsRouterHelper::findMenu($options);
 			if (!is_object($menu))
 			{

--- a/component/frontend/views/browses/tmpl/bleedingedge.xml
+++ b/component/frontend/views/browses/tmpl/bleedingedge.xml
@@ -5,10 +5,13 @@
 				<![CDATA[ARS_BROWSE_BLEEDINGEDGE_DESC]]>
 		</message>
 	</layout>
+	<fields name="request">
+		<fieldset name="request">
+			<field name="vgroupid" type="sql" default="" label="COM_ARS_COMMON_VGROUP_SELECT_LABEL" description="" query="SELECT '' AS `id`, 'All' AS `title` UNION SELECT `id`, `title` FROM `#__ars_vgroups`" key_field="id" value_field="title" />
+		</fieldset>
+	</fields>
 	<fields name="params">
 		<fieldset name="basic" label="COM_ARS_FIELDSET_BASIC">
-			<field name="vgroupid" type="sql" default="" label="COM_ARS_COMMON_VGROUP_SELECT_LABEL" description="" query="SELECT '' AS `id`, 'All' AS `title` UNION SELECT `id`, `title` FROM `#__ars_vgroups`" key_field="id" value_field="title" />
-
 			<field name="grouping" type="hidden" default="normal" />
 
 			<field name="orderby" type="list" default="order" label="ARS_BROWSE_REPOSITORY_ORDERBY_LBL" description="ARS_BROWSE_REPOSITORY_ORDERBY_DESC">

--- a/component/frontend/views/browses/tmpl/normal.xml
+++ b/component/frontend/views/browses/tmpl/normal.xml
@@ -5,10 +5,13 @@
 				<![CDATA[ARS_BROWSE_NORMAL_DESC]]>
 		</message>
 	</layout>
+	<fields name="request">
+		<fieldset name="request">
+			<field name="vgroupid" type="sql" default="" label="COM_ARS_COMMON_VGROUP_SELECT_LABEL" description="" query="SELECT '' AS `id`, 'All' AS `title` UNION SELECT `id`, `title` FROM `#__ars_vgroups`" key_field="id" value_field="title" />
+		</fieldset>
+	</fields>
 	<fields name="params">
 		<fieldset name="basic" label="COM_ARS_FIELDSET_BASIC">
-			<field name="vgroupid" type="sql" default="" label="COM_ARS_COMMON_VGROUP_SELECT_LABEL" description="" query="SELECT '' AS `id`, 'All' AS `title` UNION SELECT `id`, `title` FROM `#__ars_vgroups`" key_field="id" value_field="title" />
-
 			<field name="grouping" type="hidden" default="normal" />
 				<field name="orderby" type="list" default="order" label="ARS_BROWSE_REPOSITORY_ORDERBY_LBL" description="ARS_BROWSE_REPOSITORY_ORDERBY_DESC">
 						<option value="none">ARS_BROWSE_REPOSITORY_ORDERBY_NO</option>


### PR DESCRIPTION
Continuing on from #65 this adjusts the routing logic to ensure that menu items which use a visual group to filter on should generate a correct menu item.  This moves the `vgroupid` field to the request section of the menu item editor, adds the ID to the menu lookup as needed, and adjusts the `ArsModelBrowses` model to check for the ID in the request first and then fall back to the params.  For testing, I've pushed these changes to the `joomla.org` project as well as my own website to verify that routes with the new logic are correctly built and that existing routes are unaffected.
