### PR TITLE
Missing translations

### DIFF
--- a/translations/component/backend/en-GB/en-GB.com_ars.ini
+++ b/translations/component/backend/en-GB/en-GB.com_ars.ini
@@ -635,6 +635,9 @@ COM_ARS_CONFIG_S3_METHOD_DESC="Specify the request signature method. This is use
 COM_ARS_CONFIG_S3_SIGNATURE_V4="v4 (newer, preferred)"
 COM_ARS_CONFIG_S3_SIGNATURE_V2="v2 (legacy mode)"
 
+COM_ARS_CONFIG_S3_SSL_LABEL="Use SSL"
+COM_ARS_CONFIG_S3_SSL_DESC="Should ARS use SSL connections to Amazon S3?"
+
 ;; ======================================================================
 ;; Added / modified on 2.5.0
 ;; ======================================================================


### PR DESCRIPTION
Missing translations from https://github.com/akeeba/release-system/commit/fdcbc120c969a955a8aa92b5e8cccb03e58fee41.  Guessed on the text based on code use.