### PR TITLE
Fixed update category ID parameter type so cache works correctly

### DIFF
--- a/component/frontend/controllers/update.php
+++ b/component/frontend/controllers/update.php
@@ -149,7 +149,7 @@ class ArsControllerUpdate extends F0FController
 			'task'   => 'CMD',
 			'format' => 'CMD',
 			'layout' => 'CMD',
-			'id'     => 'INT',
+			'id'     => 'CMD',
 			'dlid'   => 'STRING',
 		);
 		$this->display(true, $registeredURLParams);


### PR DESCRIPTION
Cache does not work correctly for the `category` task of the `update` controller due to an incorrect entry in the `$registeredURLParams` array that is passed to `display()`. In this task, `id` should be of the type `CMD` and not `INT`.

Before fix, the first rendered category update xml content is served no matter what value is sent for `id`. After fix, cached xml displays properly.