### PR TITLE
Filtering Categories by Visual Group didn't work

### DIFF
--- a/component/backend/Model/Categories.php
+++ b/component/backend/Model/Categories.php
@@ -153,7 +153,7 @@ class Categories extends DataModel
 		$db = $this->getDbo();
 
 		// Visual Groups filter
-		$fltVgroup = $this->getState('vgroup', null, 'int');
+		$fltVgroup = $this->getState('vgroup_id', null, 'int');
 
 		if ($fltVgroup)
 		{


### PR DESCRIPTION
If you set a visual group in the categories in a menu item, then it doesn't work properly. Apply this patch and it does.

Note I don't *think* there are any other uses of this filter in the model - but I didn't look that hard.