### PR TITLE
Update arslatest.php

### DIFF
--- a/plugins/content/arslatest/arslatest.php
+++ b/plugins/content/arslatest/arslatest.php
@@ -145,6 +145,7 @@ class plgContentArslatest extends JPlugin
 		      ->published(1)
 		      ->latest(true)
 		      ->access_user($container->platform->getUser()->id)
+		      ->category_id(0)
 		      ->with(['items', 'category']);
 
 		/** @var \FOF30\Model\DataModel\Collection $releases */


### PR DESCRIPTION
Though I risk to meet hysterics again, I will try.

I tried to use the plugin to generate several buttons. When the joomla session is clear it works perfect.
I use code like this:
{arslatest item_link '*.zip' Category 1}
{arslatest item_link '*.zip' Category 2}

If I browse ars and later return to the page with the buttons, only one button works - other links are empty. This is because when I browse ars, the ars category id I browse is stored to joomla session or something like that. So when I return to the page with several buttons, the model filters use the latest ars category id I was browsing.

By setting ->category_id(0) I make the model to look throughout all categories again. Maybe this change kills some caching idea. But I cannot find any other way to make the plugin work with several buttons.