### PR TITLE
Update category page url to avoid generating incorrect url in breadcrumbs

### DIFF
--- a/component/frontend/Helper/Breadcrumbs.php
+++ b/component/frontend/Helper/Breadcrumbs.php
@@ -105,7 +105,7 @@ class Breadcrumbs
 				$Itemid = empty($Itemid) ? '' : '&Itemid=' . $Itemid;
 
 				$rootName = $name;
-				$rootURI = JRoute::_('index.php?option=com_ars&view=category&id=' . $id . $Itemid);
+				$rootURI = JRoute::_('index.php?option=com_ars&view=Releases&category_id=' . $id . $Itemid);
 			}
 
 			if (!is_null($rootName) && isset($rootURI))

--- a/component/frontend/Helper/Breadcrumbs.php
+++ b/component/frontend/Helper/Breadcrumbs.php
@@ -156,7 +156,7 @@ class Breadcrumbs
 				$Itemid = empty($Itemid) ? '' : '&Itemid=' . $Itemid;
 
 				$rootName = $name;
-				$rootURI = JRoute::_('index.php?option=com_ars&view=release&id=' . $id . $Itemid);
+				$rootURI = JRoute::_('index.php?option=com_ars&view=Releases&category_id=' . $id . $Itemid);
 			}
 
 			if (isset($rootName) && isset($rootURI))

--- a/component/frontend/Helper/Breadcrumbs.php
+++ b/component/frontend/Helper/Breadcrumbs.php
@@ -156,7 +156,7 @@ class Breadcrumbs
 				$Itemid = empty($Itemid) ? '' : '&Itemid=' . $Itemid;
 
 				$rootName = $name;
-				$rootURI = JRoute::_('index.php?option=com_ars&view=Releases&category_id=' . $id . $Itemid);
+				$rootURI = JRoute::_('index.php?option=com_ars&view=Items&release_id=' . $id . $Itemid);
 			}
 
 			if (isset($rootName) && isset($rootURI))


### PR DESCRIPTION
Change category page urls from
$rootURI = JRoute::_('index.php?option=com_ars&view=category&id=' . $id . $Itemid);
to
$rootURI = JRoute::_('index.php?option=com_ars&view=Releases&category_id=' . $id . $Itemid);