### PR TITLE
Items on latest view doesn't respect menu order

### DIFF
--- a/component/frontend/Controller/Latest.php
+++ b/component/frontend/Controller/Latest.php
@@ -72,6 +72,7 @@ class Latest extends Controller
 		/** @var Releases $model */
 		$model = $this->getModel();
 		$model->reset(true)
+		      ->orderby_filter($params->get('rel_orderby', 'order'))
 		      ->published(1)
 		      ->latest(true)
 		      ->access_user($this->container->platform->getUser()->id)

--- a/component/frontend/View/Latest/tmpl/category.blade.php
+++ b/component/frontend/View/Latest/tmpl/category.blade.php
@@ -90,7 +90,7 @@ switch ($release->maturity)
 	</dl>
 
 	<table class="table table-striped">
-		@foreach($release->items->filter(function ($item)
+		@foreach($release->items->sortBy('ordering')->filter(function ($item)
 		{
 			return \Akeeba\ReleaseSystem\Site\Helper\Filter::filterItem($item, true);
 		}) as $i)


### PR DESCRIPTION
First I'm just going to say this isn't a valid solution as it's hardcoding a value but it fixed my issue and maybe it'll point someone to the "right" fix.

That said...

On my site, my menu item for the latest releases view sets the item order to use the "ordering" column, however this wasn't happening.  The one query pulling data from the items table has a "ORDER BY `id` DESC" clause.  So far, the only "fix" I've found is to manually define the sorting on the collection before it's filtered and rendered.

From what I can see the only place using the `items_orderby` config value from the menu params is the frontend's Item controller.