### PR TITLE
Latest Releases Item Ordering Fixes

### DIFF
--- a/component/frontend/View/Latest/tmpl/category.blade.php
+++ b/component/frontend/View/Latest/tmpl/category.blade.php
@@ -90,7 +90,7 @@ switch ($release->maturity)
 	</dl>
 
 	<table class="table table-striped">
-		@foreach($release->items->sortBy($this->params->get('items_orderby', 'none'))->filter(function ($item)
+		@foreach($release->items->sortBy($this->params->get('items_orderby', 'ordering'))->filter(function ($item)
 		{
 			return \Akeeba\ReleaseSystem\Site\Helper\Filter::filterItem($item, true);
 		}) as $i)

--- a/component/frontend/views/Latest/tmpl/latest.xml
+++ b/component/frontend/views/Latest/tmpl/latest.xml
@@ -38,14 +38,14 @@
             </field>
 
             <field name="@spacer" type="spacer" default="" label="" description=""/>
-            <field name="items_orderby" type="list" default="order" label="ARS_ITEMS_ORDERBY_LBL"
+            <field name="items_orderby" type="list" default="ordering" label="ARS_ITEMS_ORDERBY_LBL"
                    description="ARS_ITEMS_ORDERBY_DESC">
                 <option value="none">ARS_BROWSE_REPOSITORY_ORDERBY_NO</option>
                 <option value="alpha">ARS_BROWSE_REPOSITORY_ORDERBY_ALPHA</option>
                 <option value="ralpha">ARS_BROWSE_REPOSITORY_ORDERBY_RALPHA</option>
                 <option value="created">ARS_BROWSE_REPOSITORY_ORDERBY_CREATED</option>
                 <option value="rcreated">ARS_BROWSE_REPOSITORY_ORDERBY_RCREATED</option>
-                <option value="order">ARS_BROWSE_REPOSITORY_ORDERBY_ORDER</option>
+                <option value="ordering">ARS_BROWSE_REPOSITORY_ORDERBY_ORDER</option>
             </field>
         </fieldset>
 


### PR DESCRIPTION
Two changes:

1) Changed the value of the ordering option for items sorting from "order" to "ordering".  This parameter doesn't go through the model which handles converting that over but is used as a sort modifier on the collection so it needs to match the actual column name.

2) Changed the default parameter value in the layout to match the default in the menu item's configuration.  Seems more consistent this way.