### PR TITLE
Tweaks to ensure S3 file lists are correctly pulled

### DIFF
--- a/component/backend/Model/Items.php
+++ b/component/backend/Model/Items.php
@@ -752,7 +752,7 @@ class Items extends DataModel
 					{
 						$check = substr($folder, 5);
 						$s3 = AmazonS3::getInstance();
-						$items = $s3->getBucket('', $check);
+						$items = $s3->getBucket('', rtrim($check, '/') . '/');
 
 						if (empty($items))
 						{
@@ -1040,7 +1040,7 @@ class Items extends DataModel
 			}
 
 			$s3    = AmazonS3::getInstance();
-			$items = $s3->getBucket('', $directory . '/');
+			$items = $s3->getBucket('', rtrim($directory, '/') . '/');
 
 			if (empty($items))
 			{
@@ -1117,7 +1117,7 @@ class Items extends DataModel
 		if ($useS3)
 		{
 			$s3       = AmazonS3::getInstance();
-			$allFiles = $s3->getBucket('', $directory, null, null, null, true);
+			$allFiles = $s3->getBucket('', rtrim($directory, '/') . '/', null, null, null, true);
 
 			if (!empty($allFiles))
 			{


### PR DESCRIPTION
I hit a couple of snags where the list of files wasn't correctly pulled from the S3 bucket (one of those being the file selector in the Item edit view).  These changes ensure the files list comes back correctly.