### PR TITLE
Release version number comparison bug

### DIFF
--- a/component/backend/Model/Mixin/Assertions.php
+++ b/component/backend/Model/Mixin/Assertions.php
@@ -54,7 +54,7 @@ trait Assertions
 	 */
 	protected function assertInArray($value, array $validValues, $message)
 	{
-		$this->assert(in_array($value, $validValues), $message);
+		$this->assert(in_array($value, $validValues, true), $message);
 	}
 
 	/**
@@ -69,6 +69,6 @@ trait Assertions
 	 */
 	protected function assertNotInArray($value, array $validValues, $message)
 	{
-		$this->assert(!in_array($value, $validValues), $message);
+		$this->assert(!in_array($value, $validValues, true), $message);
 	}
 }

--- a/component/backend/Model/Releases.php
+++ b/component/backend/Model/Releases.php
@@ -435,13 +435,13 @@ class Releases extends DataModel
 
 		foreach ($info as $infoitem)
 		{
-			$versions[] = '*' . $infoitem['version'] . '*';
+			$versions[] = $infoitem['version'];
 			$aliases[] = $infoitem['alias'];
 		}
 
 		$this->assertNotEmpty($this->version, 'COM_RELEASE_ERR_NEEDS_VERSION');
 
-		$this->assertNotInArray('*' . $this->version . '*', $versions, 'COM_RELEASE_ERR_NEEDS_VERSION_UNIQUE');
+		$this->assertNotInArray($this->version, $versions, 'COM_RELEASE_ERR_NEEDS_VERSION_UNIQUE');
 
 		// If the alias is missing, auto-create a new one
 		if (!$this->alias)

--- a/component/backend/Model/Releases.php
+++ b/component/backend/Model/Releases.php
@@ -435,13 +435,13 @@ class Releases extends DataModel
 
 		foreach ($info as $infoitem)
 		{
-			$versions[] = $infoitem['version'];
+			$versions[] = '*' . $infoitem['version'] . '*';
 			$aliases[] = $infoitem['alias'];
 		}
 
 		$this->assertNotEmpty($this->version, 'COM_RELEASE_ERR_NEEDS_VERSION');
 
-		$this->assertNotInArray($this->version, $versions, 'COM_RELEASE_ERR_NEEDS_VERSION_UNIQUE');
+		$this->assertNotInArray('*' . $this->version . '*', $versions, 'COM_RELEASE_ERR_NEEDS_VERSION_UNIQUE');
 
 		// If the alias is missing, auto-create a new one
 		if (!$this->alias)


### PR DESCRIPTION
Release version number comparison fails to distinguish between 1.1 and 1.10; My simple fix wraps the version number in asterisk characters to make sure the trailing zero is taken into account when comparing the strings. Maybe you can come up with a more elegant solution.