### PR TITLE
Include vgroupid in URL params array

### DIFF
--- a/component/frontend/Controller/Category.php
+++ b/component/frontend/Controller/Category.php
@@ -60,6 +60,7 @@ class Category extends DataController
 			'format'      => 'CMD',
 			'layout'      => 'CMD',
 			'id'          => 'INT',
+			'vgroupid'    => 'INT',
 		);
 
 		$urlparams = array_merge($additionalParams, $urlparams);


### PR DESCRIPTION
If you've got Joomla's cache enabled and two menu items pointing to a Categories view with filtering for visual groups enabled, a unique cached view for those two items is not generated and instead a single cached view is used for both of those items.  Including the `vgroupid` query param into the array allows the cache to be correctly generated for the two items.