### PR TITLE
Support for marking categories as not supported

### DIFF
--- a/component/backend/Controller/Category.php
+++ b/component/backend/Controller/Category.php
@@ -25,11 +25,12 @@ class Category extends DataController
 	protected function onBeforeAdd()
 	{
 		$this->defaultsForAdd = [
-			'vgroup_id' => 0,
-			'type'      => 'normal',
-			'access'    => 1,
-			'published' => 0,
-			'language'  => '*',
+			'vgroup_id'    => 0,
+			'type'         => 'normal',
+			'access'       => 1,
+			'published'    => 0,
+			'is_supported' => 1,
+			'language'     => '*',
 		];
 
 		foreach ($this->defaultsForAdd as $k => $v)

--- a/component/backend/Model/Categories.php
+++ b/component/backend/Model/Categories.php
@@ -36,6 +36,7 @@ use FOF30\Model\DataModel;
  * @property  string  $redirect_unauth
  * @property  int     $published
  * @property  string  $language
+ * @property  int     $is_supported
  *
  * Filters:
  *
@@ -64,6 +65,7 @@ use FOF30\Model\DataModel;
  * @method  $this  nobeunpub()          nobeunpub(bool $v)
  * @method  $this  search()             search(string $v)
  * @method  $this  orderby_filter()     orderby_filter(string $orderMethod)
+ * @method  $this  is_supported()       is_supported(bool $v)
  *
  * Relations:
  *
@@ -205,6 +207,14 @@ class Categories extends DataModel
 		elseif ($fltLanguage2)
 		{
 			$query->where($db->qn('language') . ' = ' . $db->q($fltLanguage2));
+		}
+
+		// Allow filtering for only supported categories
+		$fltIsSupported = $this->getState('is_supported', false, 'bool');
+
+		if ($fltIsSupported)
+		{
+			$query->where($db->qn('is_supported') . ' = ' . $db->q(1));
 		}
 
 		// Generic search (matching title or description) filter

--- a/component/backend/View/Categories/tmpl/form.form.xml
+++ b/component/backend/View/Categories/tmpl/form.form.xml
@@ -42,6 +42,11 @@
 			   source_value="value"
 				/>
 
+		<field name="is_supported" type="Radio" label="COM_ARS_IS_SUPPORTED" default="1" class="btn-group btn-group-yesno">
+			<option value="0">JNo</option>
+			<option value="1">JYes</option>
+		</field>
+
 		<field name="language" type="Language" label="JFIELD_LANGUAGE_LABEL" default="*" client="site">
 			<option value="*">JALL_LANGUAGE</option>
 		</field>

--- a/component/backend/sql/xml/mysql.xml
+++ b/component/backend/sql/xml/mysql.xml
@@ -60,6 +60,7 @@ CREATE TABLE `#__ars_categories` (
     `show_unauth_links` TINYINT NOT NULL DEFAULT '0',
     `redirect_unauth` VARCHAR( 255 ) NOT NULL,
     `published` int(11) NOT NULL DEFAULT '1',
+    `is_supported` TINYINT NOT NULL DEFAULT '1',
 	`language` char(7) NOT NULL DEFAULT '*',
     PRIMARY KEY (`id`),
 	KEY `#___ars_categories_published` (`published`)
@@ -422,6 +423,13 @@ WHERE
 	`ls`.`primary` = 0
 	AND `ls`.`dlid` = ''
 	AND `p`.`primary` = 1
+            ]]></query>
+        </action>
+
+        <action table="#__ars_categories" canfail="0">
+            <condition type="missing" value="is_supported" />
+            <query><![CDATA[
+ALTER TABLE `#__ars_categories` ADD COLUMN `is_supported` TINYINT NOT NULL DEFAULT '1' AFTER `published`;
             ]]></query>
         </action>
     </sql>

--- a/component/frontend/Controller/Latest.php
+++ b/component/frontend/Controller/Latest.php
@@ -93,6 +93,7 @@ class Latest extends Controller
 		$categoriesModel->reset(true)
 		                ->orderby_filter($this->params->get('orderby', 'order'))
 		                ->published(1)
+		                ->is_supported((bool) $this->params->get('cat_is_supported', false))
 		                ->access_user($this->container->platform->getUser()->id)
 		                ->with([]);
 		$this->getView()->setModel('Categories', $categoriesModel);

--- a/component/frontend/View/Categories/tmpl/category.blade.php
+++ b/component/frontend/View/Categories/tmpl/category.blade.php
@@ -2,6 +2,7 @@
 defined('_JEXEC') or die;
 
 /** @var  \Akeeba\ReleaseSystem\Site\View\Categories\Html $this */
+/** @var  \Akeeba\ReleaseSystem\Site\Model\Categories $item */
 
 use Akeeba\ReleaseSystem\Site\Helper\Filter;
 use Akeeba\ReleaseSystem\Site\Helper\Router;
@@ -14,7 +15,7 @@ if (!Filter::filterItem($item, false, $this->getContainer()->platform->getUser()
 	$category_url = $item->redirect_unauth;
 }
 ?>
-<div class="ars-category-{{{ $id }}}">
+<div class="ars-category-{{{ $id }}} {{ $item->is_supported ? 'supported' : 'unsupported' }}">
 
 	<h4 class="{{ $item->type == 'bleedingedge' ? 'warning' : '' }}">
 		<a href="{{ htmlentities($category_url) }}">

--- a/component/frontend/View/Items/tmpl/default.blade.php
+++ b/component/frontend/View/Items/tmpl/default.blade.php
@@ -23,7 +23,7 @@ $released   = $this->container->platform->getDate($this->release->created);
 
 	@include('site:com_ars/Items/release', ['id' => $this->release->id, 'item' => $this->release, 'Itemid' => $this->Itemid, 'no_link' => true])
 
-	<div class="ars-items">
+	<div class="ars-items {{ $this->release->category->is_supported ? 'supported' : 'unsupported' }}">
 	@if(count($this->items))
 		@foreach($this->items as $item)
 			@include('site:com_ars/Items/item', ['item' => $item, 'Itemid' => $this->Itemid])

--- a/component/frontend/View/Items/tmpl/release.blade.php
+++ b/component/frontend/View/Items/tmpl/release.blade.php
@@ -8,6 +8,7 @@
 defined('_JEXEC') or die;
 
 /** @var  \Akeeba\ReleaseSystem\Site\View\Releases\Html $this */
+/** @var  \Akeeba\ReleaseSystem\Site\Model\Releases $item */
 
 use Akeeba\ReleaseSystem\Site\Helper\Filter;
 use Akeeba\ReleaseSystem\Site\Helper\Router;
@@ -17,7 +18,7 @@ $released = $this->container->platform->getDate($item->created);
 
 ?>
 
-<div class="ars-release-{{{ $item->id }}}">
+<div class="ars-release-{{{ $item->id }}} {{ $this->release->category->is_supported ? 'supported' : 'unsupported' }}">
 	<h4 class="text-muted">
 		{{{ $item->category->title }}}
 		{{{ $item->version }}}

--- a/component/frontend/View/Latest/tmpl/category.blade.php
+++ b/component/frontend/View/Latest/tmpl/category.blade.php
@@ -56,7 +56,7 @@ switch ($release->maturity)
 
 ?>
 
-<div class="ars-category-{{{ $item->id }}} well">
+<div class="ars-category-{{{ $item->id }}} well {{ $item->is_supported ? 'supported' : 'unsupported' }}">
 	<h4 class="{{ $item->type == 'bleedingedge' ? 'warning' : '' }}">
 		<span class="label {{{ $maturityClass }}} pull-right">
 			@lang('COM_ARS_RELEASES_MATURITY_' . $release->maturity)

--- a/component/frontend/View/Releases/tmpl/category.blade.php
+++ b/component/frontend/View/Releases/tmpl/category.blade.php
@@ -2,6 +2,7 @@
 defined('_JEXEC') or die;
 
 /** @var  \Akeeba\ReleaseSystem\Site\View\Categories\Html $this */
+/** @var  \Akeeba\ReleaseSystem\Site\Model\Categories $item */
 
 use Akeeba\ReleaseSystem\Site\Helper\Filter;
 use Akeeba\ReleaseSystem\Site\Helper\Router;
@@ -14,7 +15,7 @@ if (!Filter::filterItem($item, false, $this->getContainer()->platform->getUser()
 	$category_url = $item->redirect_unauth;
 }
 ?>
-<div class="ars-category-{{{ $id }}}">
+<div class="ars-category-{{{ $id }}} {{ $item->category->is_supported ? 'supported' : 'unsupported' }}">
 
 	<h4 class="text-muted">
 		{{{ $item->title }}}

--- a/component/frontend/View/Releases/tmpl/default.blade.php
+++ b/component/frontend/View/Releases/tmpl/default.blade.php
@@ -21,7 +21,7 @@ defined('_JEXEC') or die;
 
 	@include('site:com_ars/Releases/category', ['id' => $this->category->id, 'item' => $this->category, 'Itemid' => $this->Itemid, 'no_link' => true])
 
-	<div class="ars-releases">
+	<div class="ars-releases{{ $this->category->is_supported ? 'supported' : 'unsupported' }}">
 	@if(count($this->items))
 		@foreach($this->items as $item)
 				@include('site:com_ars/Releases/release', ['item' => $item, 'Itemid' => $this->Itemid])

--- a/component/frontend/views/Latest/tmpl/latest.xml
+++ b/component/frontend/views/Latest/tmpl/latest.xml
@@ -47,6 +47,13 @@
                 <option value="rcreated">ARS_BROWSE_REPOSITORY_ORDERBY_RCREATED</option>
                 <option value="ordering">ARS_BROWSE_REPOSITORY_ORDERBY_ORDER</option>
             </field>
+
+            <field name="@spacer" type="spacer" default="" label="" description=""/>
+            <field name="cat_is_supported" type="radio" default="0" label="ARS_CATEGORY_IS_SUPPORTED_LBL"
+                   description="ARS_CATEGORY_IS_SUPPORTED_DESC" class="btn-group btn-group-yesno">
+                <option value="0">JNo</option>
+                <option value="1">JYes</option>
+            </field>
         </fieldset>
 
         <fieldset name="advanced" label="COM_ARS_FIELDSET_ADVANCED">

--- a/component/language/backend/en-GB/en-GB.com_ars.ini
+++ b/component/language/backend/en-GB/en-GB.com_ars.ini
@@ -662,3 +662,8 @@ COM_ARS_RELEASES_NODELETE_ITEM="Cannot delete Release: you have to delete its It
 COM_ARS_DLIDLABELS_FIELD_TRASH="Trash"
 
 COM_ARS_LBL_ENVIRONMENT_DELETED="Environment Deleted"
+
+;; ======================================================================
+;; Added / modified after 3.2.4
+;; ======================================================================
+COM_ARS_IS_SUPPORTED="Is Supported?"

--- a/component/language/backend/en-GB/en-GB.com_ars.sys.ini
+++ b/component/language/backend/en-GB/en-GB.com_ars.sys.ini
@@ -99,3 +99,9 @@ ARS_DLIDLABELS_DEFAULT_DESC="Allows the user to manage add-on Download IDs for u
 ;; ======================================================================
 COM_ARS_VIEW_JED_XML_TITLE="JED Remote XML"
 COM_ARS_VIEW_JED_XML_DESC="XML file for automatically updating the extension listing in the Joomla! Extensions Directory"
+
+;; ======================================================================
+;; Added / modified after 3.2.4
+;; ======================================================================
+ARS_CATEGORY_IS_SUPPORTED_LBL="Only Supported Categories"
+ARS_CATEGORY_IS_SUPPORTED_DESC="Only releases from supported categories will be shown"


### PR DESCRIPTION
This is a feature we use on downloads.joomla.org as a means for marking releases as unsupported (since we've grouped each major version branch as an ARS category it works well).

- Adds an `is_supported` property to the categories model
- Adds an option to the latest releases view to filter for only supported categories
- Adds two new CSS classes, `supported` and `unsupported`, to various frontend containers (primarily containers which hold categories, for the child views this is generally the container wrapping whatever item type is displayed; this is how we change the stripe color on https://downloads.joomla.org/cms as an example)

We added this field to be able to quickly be able to display a notification that a release category is no longer supported (i.e. the alert on https://downloads.joomla.org/cms/joomla25), this can have practical benefits for others using this software to communicate support statuses without completely hiding the unsupported categories too