### PR TITLE
Extend ACL to the category level

### DIFF
--- a/component/backend/Controller/Category.php
+++ b/component/backend/Controller/Category.php
@@ -24,6 +24,19 @@ class Category extends DataController
 
 	protected function onBeforeAdd()
 	{
+		if (!$this->checkACL('@Add'))
+		{
+			$returnUrl = 'index.php?option=' . $this->container->componentName . '&view=' . $this->container->inflector->pluralize($this->view) . $this->getItemidURLSuffix();
+
+			$this->setRedirect(
+				$returnUrl,
+				\JText::_('JLIB_APPLICATION_ERROR_CREATE_RECORD_NOT_PERMITTED'),
+				'error'
+			);
+
+			return false;
+		}
+
 		$this->defaultsForAdd = [
 			'vgroup_id' => 0,
 			'type'      => 'normal',

--- a/component/backend/Controller/Item.php
+++ b/component/backend/Controller/Item.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use FOF30\Container\Container;
 use FOF30\Controller\DataController;
+use FOF30\Controller\Exception\ItemNotFound;
 
 class Item extends DataController
 {
@@ -26,6 +27,22 @@ class Item extends DataController
 
 	protected function onBeforeApplySave(&$data)
 	{
+		if ($data['release_id'])
+		{
+			/** @var \Akeeba\ReleaseSystem\Admin\Model\Releases $releasesModel */
+			$releasesModel = $this->getModel('Releases');
+			$releasesModel->load($data['release_id']);
+
+			$permission = $data['id'] ? 'core.edit' : 'core.create';
+
+			if (!$this->container->platform->getUser()->authorise($permission, $this->container->componentName . '.category.' . $releasesModel->category_id))
+			{
+				$message = $data['id'] ? 'JLIB_APPLICATION_ERROR_CREATE_RECORD_NOT_PERMITTED' : 'JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED';
+
+				throw new \RuntimeException(\JText::_($message), 403);
+			}
+		}
+
 		// When you deselect all items Chosen doesn't return any items in the request :(
 		if (!isset($data['groups']))
 		{
@@ -63,4 +80,49 @@ class Item extends DataController
 		}
 	}
 
+	protected function onBeforeDelete()
+	{
+		/** @var \Akeeba\ReleaseSystem\Admin\Model\Items $model */
+		$model = $this->getModel()->savestate(false);
+
+		// If there is no record loaded, try loading a record based on the id passed in the input object
+		if (!$model->getId())
+		{
+			$ids = $this->getIDsFromRequest($model, true);
+
+			if ($model->getId() != reset($ids))
+			{
+				$key = strtoupper($this->container->componentName . '_ERR_' . $model->getName() . '_NOTFOUND');
+				throw new ItemNotFound(\JText::_($key), 404);
+			}
+		}
+
+		if (!$this->container->platform->getUser()->authorise('core.delete', $this->container->componentName . '.category.' . $model->release->category_id))
+		{
+			throw new \RuntimeException(\JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), 403);
+		}
+	}
+
+	protected function onBeforeEdit()
+	{
+		/** @var \Akeeba\ReleaseSystem\Admin\Model\Items $model */
+		$model = $this->getModel()->savestate(false);
+
+		// If there is no record loaded, try loading a record based on the id passed in the input object
+		if (!$model->getId())
+		{
+			$ids = $this->getIDsFromRequest($model, true);
+
+			if ($model->getId() != reset($ids))
+			{
+				$key = strtoupper($this->container->componentName . '_ERR_' . $model->getName() . '_NOTFOUND');
+				throw new ItemNotFound(\JText::_($key), 404);
+			}
+		}
+
+		if (!$this->container->platform->getUser()->authorise('core.edit', $this->container->componentName . '.category.' . $model->release->category_id))
+		{
+			throw new \RuntimeException(\JText::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN'), 403);
+		}
+	}
 }

--- a/component/backend/Controller/Release.php
+++ b/component/backend/Controller/Release.php
@@ -11,11 +11,24 @@ defined('_JEXEC') or die;
 
 use Akeeba\ReleaseSystem\Admin\Model\Releases;
 use FOF30\Controller\DataController;
+use FOF30\Controller\Exception\ItemNotFound;
 
 class Release extends DataController
 {
 	protected function onBeforeApplySave(&$data)
 	{
+		if ($data['category_id'])
+		{
+			$permission = $data['id'] ? 'core.edit' : 'core.create';
+
+			if (!$this->container->platform->getUser()->authorise($permission, $this->container->componentName . '.category.' . $data['category_id']))
+			{
+				$message = $data['id'] ? 'JLIB_APPLICATION_ERROR_CREATE_RECORD_NOT_PERMITTED' : 'JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED';
+
+				throw new \RuntimeException(\JText::_($message), 403);
+			}
+		}
+
 		// When you deselect all items Chosen doesn't return any items in the request :(
 		if (!isset($data['groups']))
 		{
@@ -39,6 +52,52 @@ class Release extends DataController
 			{
 				$this->defaultsForAdd[$k] = $stateValue;
 			}
+		}
+	}
+
+	protected function onBeforeDelete()
+	{
+		/** @var \Akeeba\ReleaseSystem\Admin\Model\Releases $model */
+		$model = $this->getModel()->savestate(false);
+
+		// If there is no record loaded, try loading a record based on the id passed in the input object
+		if (!$model->getId())
+		{
+			$ids = $this->getIDsFromRequest($model, true);
+
+			if ($model->getId() != reset($ids))
+			{
+				$key = strtoupper($this->container->componentName . '_ERR_' . $model->getName() . '_NOTFOUND');
+				throw new ItemNotFound(\JText::_($key), 404);
+			}
+		}
+
+		if (!$this->container->platform->getUser()->authorise('core.delete', $this->container->componentName . '.category.' . $model->category_id))
+		{
+			throw new \RuntimeException(\JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), 403);
+		}
+	}
+
+	protected function onBeforeEdit()
+	{
+		/** @var \Akeeba\ReleaseSystem\Admin\Model\Releases $model */
+		$model = $this->getModel()->savestate(false);
+
+		// If there is no record loaded, try loading a record based on the id passed in the input object
+		if (!$model->getId())
+		{
+			$ids = $this->getIDsFromRequest($model, true);
+
+			if ($model->getId() != reset($ids))
+			{
+				$key = strtoupper($this->container->componentName . '_ERR_' . $model->getName() . '_NOTFOUND');
+				throw new ItemNotFound(\JText::_($key), 404);
+			}
+		}
+
+		if (!$this->container->platform->getUser()->authorise('core.edit', $this->container->componentName . '.category.' . $model->category_id))
+		{
+			throw new \RuntimeException(\JText::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN'), 403);
 		}
 	}
 }

--- a/component/backend/Form/Field/AccessAwareItemTitle.php
+++ b/component/backend/Form/Field/AccessAwareItemTitle.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @package   AkeebaReleaseSystem
+ * @copyright Copyright (c)2010 Nicholas K. Dionysopoulos
+ * @license   GNU General Public License version 3, or later
+ */
+
+namespace Akeeba\ReleaseSystem\Admin\Form\Field;
+
+defined('_JEXEC') or die;
+
+use Akeeba\ReleaseSystem\Admin\Model\Items;
+use FOF30\Form\Field\Text;
+
+class AccessAwareItemTitle extends Text
+{
+	/**
+	 * Get the rendering of this field type for a repeatable (grid) display,
+	 * e.g. in a view listing many item (typically a "browse" task)
+	 *
+	 * @since 2.0
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getRepeatable()
+	{
+		$user = \JFactory::getUser();
+
+		if ($user->authorise('core.admin'))
+		{
+			return parent::getRepeatable();
+		}
+
+		/** @var Items $item */
+		$item = $this->item;
+
+		$permission = 'com_ars.category.'.$item->release->category_id;
+
+		if (!$user->authorise('core.edit', $permission))
+		{
+			$this->element['url'] = false;
+		}
+
+		return parent::getRepeatable();
+	}
+}

--- a/component/backend/Form/Field/AccessAwareReleaseVersion.php
+++ b/component/backend/Form/Field/AccessAwareReleaseVersion.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @package   AkeebaReleaseSystem
+ * @copyright Copyright (c)2010 Nicholas K. Dionysopoulos
+ * @license   GNU General Public License version 3, or later
+ */
+
+namespace Akeeba\ReleaseSystem\Admin\Form\Field;
+
+defined('_JEXEC') or die;
+
+use Akeeba\ReleaseSystem\Admin\Model\Releases;
+use FOF30\Form\Field\Text;
+
+class AccessAwareReleaseVersion extends Text
+{
+	/**
+	 * Get the rendering of this field type for a repeatable (grid) display,
+	 * e.g. in a view listing many item (typically a "browse" task)
+	 *
+	 * @since 2.0
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getRepeatable()
+	{
+		$user = \JFactory::getUser();
+
+		if ($user->authorise('core.admin'))
+		{
+			return parent::getRepeatable();
+		}
+
+		/** @var Releases $item */
+		$item = $this->item;
+
+		$permission = 'com_ars.category.'.$item->category_id;
+
+		if (!$user->authorise('core.edit', $permission))
+		{
+			$this->element['url'] = false;
+		}
+
+		return parent::getRepeatable();
+	}
+}

--- a/component/backend/Form/Field/AccessAwareTitle.php
+++ b/component/backend/Form/Field/AccessAwareTitle.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @package   AkeebaReleaseSystem
+ * @copyright Copyright (c)2010 Nicholas K. Dionysopoulos
+ * @license   GNU General Public License version 3, or later
+ */
+
+namespace Akeeba\ReleaseSystem\Admin\Form\Field;
+
+defined('_JEXEC') or die;
+
+use FOF30\Form\Field\Text;
+
+class AccessAwareTitle extends Text
+{
+	/**
+	 * Get the rendering of this field type for a repeatable (grid) display,
+	 * e.g. in a view listing many item (typically a "browse" task)
+	 *
+	 * @since 2.0
+	 *
+	 * @return  string  The field HTML
+	 */
+	public function getRepeatable()
+	{
+		$user = \JFactory::getUser();
+
+		$permission = $this->element['permission'] ? (string) $this->element['permission'] : '';
+
+		if (!$permission || $user->authorise('core.admin'))
+		{
+			return parent::getRepeatable();
+		}
+
+		$permission = $this->parseFieldTags($permission);
+
+		if (!$user->authorise('core.edit', $permission))
+		{
+			$this->element['url'] = false;
+		}
+
+		return parent::getRepeatable();
+	}
+}

--- a/component/backend/Model/Categories.php
+++ b/component/backend/Model/Categories.php
@@ -20,6 +20,7 @@ use FOF30\Model\DataModel;
  * Fields:
  *
  * @property  int     $id
+ * @property  int     $asset_id
  * @property  string  $title
  * @property  string  $alias
  * @property  string  $description
@@ -40,6 +41,7 @@ use FOF30\Model\DataModel;
  * Filters:
  *
  * @method  $this  id()                 id(int $v)
+ * @method  $this  asset_id()           asset_id(int $v)
  * @method  $this  title()              title(string $v)
  * @method  $this  alias()              alias(string $v)
  * @method  $this  description()        description(string $v)
@@ -139,6 +141,7 @@ class Categories extends DataModel
 		$this->addBehaviour('Filters');
 		$this->addBehaviour('Created');
 		$this->addBehaviour('Modified');
+		$this->addBehaviour('Assets');
 
 		// Some filters we will have to handle programmatically so we need to exclude them from the behaviour
 		$this->blacklistFilters([
@@ -493,5 +496,54 @@ class Categories extends DataModel
 	protected function onAfterUnlock($ignored = array())
 	{
 		$this->ignorePreSaveChecks = false;
+	}
+
+	/**
+	 * Method to return the title to use for the asset table.  In
+	 * tracking the assets a title is kept for each asset so that there is some
+	 * context available in a unified access manager.  Usually this would just
+	 * return $this->title or $this->name or whatever is being used for the
+	 * primary name of the row. If this method is not overridden, the asset name is used.
+	 *
+	 * @return  string  The string to use as the title in the asset table.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function getAssetTitle()
+	{
+		return $this->title;
+	}
+
+	/**
+	 * Method to get the parent asset under which to register this one.
+	 * By default, all assets are registered to the ROOT node with ID,
+	 * which will default to 1 if none exists.
+	 * The extended class can define a table and id to lookup.  If the
+	 * asset does not exist it will be created.
+	 *
+	 * @param   DataModel  $model  A model object for the asset parent.
+	 * @param   integer   $id     Id to look up
+	 *
+	 * @return  integer
+	 */
+	public function getAssetParentId($model = null, $id = null)
+	{
+		$db = $this->getDbo();
+
+		// Build the query to get the asset id for the component.
+		$query = $db->getQuery(true)
+			->select($db->quoteName('id'))
+			->from($db->quoteName('#__assets'))
+			->where($db->quoteName('name') . ' = ' . $db->quote('com_ars'));
+
+		// Get the asset id from the database.
+		$db->setQuery($query);
+
+		if ($result = $db->loadResult())
+		{
+			return (int) $result;
+		}
+
+		return parent::getAssetParentId($model, $id);
 	}
 }

--- a/component/backend/View/Categories/tmpl/form.default.xml
+++ b/component/backend/View/Categories/tmpl/form.default.xml
@@ -29,8 +29,9 @@
 	<fieldset name="items">
 		<field name="ordering" type="Ordering" class="input-mini input-sm"/>
 		<field name="id" type="SelectRow"/>
-		<field name="title" type="Sortable"
-			   url="index.php?option=com_ars&amp;view=Category&amp;id=[ITEM:ID]"/>
+		<field name="title" type="AccessAwareTitle"
+			   url="index.php?option=com_ars&amp;view=Category&amp;id=[ITEM:ID]"
+			   permission="com_ars.category.[ITEM:ID]"/>
 		<field name="vgroup_id" type="Model"
 			   model="VisualGroups" key_field="id" value_field="title" translate="false" none="–––"
 			   show_link="true"

--- a/component/backend/View/Categories/tmpl/form.form.xml
+++ b/component/backend/View/Categories/tmpl/form.form.xml
@@ -56,4 +56,15 @@
 			   buttons="true"/>
 
 	</fieldset>
+
+	<fieldset name="permissions" label="JCONFIG_PERMISSIONS_LABEL" description="JCONFIG_PERMISSIONS_DESC" class="span12">
+
+		<field name="rules" type="Rules" label="JCONFIG_PERMISSIONS_LABEL"
+			   class="inputbox"
+			   filter="rules"
+			   component="com_ars"
+			   section="category"
+				/>
+
+	</fieldset>
 </form>

--- a/component/backend/View/Items/tmpl/form.default.xml
+++ b/component/backend/View/Items/tmpl/form.default.xml
@@ -63,7 +63,7 @@
         <!--<field name="release.category.title" type="Text"/>-->
         <!--<field name="release.version" type="Text"/>-->
 
-        <field name="title" type="Sortable"
+        <field name="title" type="AccessAwareItemTitle"
                url="index.php?option=com_ars&amp;view=Item&amp;id=[ITEM:ID]"/>
 
         <field name="type" type="GenericList" label="LBL_ITEMS_TYPE">

--- a/component/backend/View/Releases/tmpl/form.default.xml
+++ b/component/backend/View/Releases/tmpl/form.default.xml
@@ -36,7 +36,7 @@
 			   key_field="id"
 			   value_field="title"
 				/>
-		<field name="version" type="Text"
+		<field name="version" type="AccessAwareReleaseVersion"
 			   url="index.php?option=com_ars&amp;view=Release&amp;id=[ITEM:ID]"/>
 		<field name="maturity" type="GenericList" label="COM_ARS_RELEASES_FIELD_MATURITY">
 			<option value="alpha">COM_ARS_RELEASES_MATURITY_ALPHA</option>

--- a/component/backend/access.xml
+++ b/component/backend/access.xml
@@ -13,4 +13,11 @@
 		<action name="core.edit" title="JACTION_EDIT" description="JACTION_EDIT_COMPONENT_DESC" />
 		<action name="core.edit.state" title="JACTION_EDITSTATE" description="JACTION_EDITSTATE_COMPONENT_DESC" />
 	</section>
+
+	<section name="category">
+		<action name="core.create" title="JACTION_CREATE" description="JACTION_CREATE_COMPONENT_DESC" />
+		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />
+		<action name="core.edit" title="JACTION_EDIT" description="JACTION_EDIT_COMPONENT_DESC" />
+		<action name="core.edit.state" title="JACTION_EDITSTATE" description="JACTION_EDITSTATE_COMPONENT_DESC" />
+	</section>
 </access>

--- a/component/backend/sql/xml/mysql.xml
+++ b/component/backend/sql/xml/mysql.xml
@@ -42,6 +42,7 @@ CREATE TABLE `#__ars_vgroups` (
             <query><![CDATA[
 CREATE TABLE `#__ars_categories` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT,
+    `asset_id` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'FK to the #__assets table.'
     `title` varchar(255) NOT NULL,
     `alias` varchar(255) NOT NULL,
     `description` mediumtext,
@@ -422,6 +423,13 @@ WHERE
 	`ls`.`primary` = 0
 	AND `ls`.`dlid` = ''
 	AND `p`.`primary` = 1
+            ]]></query>
+        </action>
+
+        <action table="#__ars_categories" canfail="0">
+            <condition type="missing" value="asset_id" />
+            <query><![CDATA[
+ALTER TABLE `#__ars_categories` ADD COLUMN `asset_id` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'FK to the #__assets table.' AFTER `id`;
             ]]></query>
         </action>
     </sql>


### PR DESCRIPTION
This should be all elements of https://github.com/joomla/downloads.joomla.org/pull/72 as long as I didn't miss anything.

This will extend the ACL system to the ARS category level, which can allow users who are in shared environments to restrict who has access to create releases in different categories (i.e. for Joomla we need to be able to restrict who can create CMS releases, extension releases, and language releases).  The ACL will exist natively as part of a category and inherit from the component.  For releases and items, CRUD tasks will look for the parent category to resolve the available permissions.