### PR TITLE
Use a date format for releases without time

### DIFF
--- a/component/frontend/View/Releases/tmpl/release.blade.php
+++ b/component/frontend/View/Releases/tmpl/release.blade.php
@@ -86,7 +86,7 @@ $this->getContainer()->template->addJSInline($js);
 	</h4>
 	<p>
 		<strong>@lang('LBL_RELEASES_RELEASEDON')</strong>:
-		@jhtml('date', $released, JText::_('DATE_FORMAT_LC2'))
+		@jhtml('date', $released, JText::_('DATE_FORMAT_LC1'))
 		<button class="akeeba-btn--dark--small release-info-toggler" type="button"
 				data-target="#ars-release-{{{ $item->id }}}-info">
 			<span class="akion-information-circled"></span>
@@ -102,7 +102,7 @@ $this->getContainer()->template->addJSInline($js);
 			</tr>
 			<tr>
 				<td>@lang('LBL_RELEASES_RELEASEDON')</td>
-				<td>@jhtml('date', $released, JText::_('DATE_FORMAT_LC2'))</td>
+				<td>@jhtml('date', $released, JText::_('DATE_FORMAT_LC1'))</td>
 			</tr>
 		@if($this->params->get('show_downloads', 1))
 			<tr>


### PR DESCRIPTION
The date format of releases do show a time, but the release itself has only a date field, so it shows always the time 00:00.

![image](https://user-images.githubusercontent.com/251072/42075877-3d652320-7b73-11e8-9176-c938b80b8f90.png)

This pr changes to a date format to be displayed without time.