### PR TITLE
When filtering latest release, also account for published filter

### DIFF
--- a/component/backend/Model/Releases.php
+++ b/component/backend/Model/Releases.php
@@ -350,15 +350,17 @@ class Releases extends DataModel
 
 		// Latest version filter. Use as $releases->published(1)->latest(true)->get(true)
 		$fltLatest = $this->getState('latest', false, 'bool');
+		$fltPublished = $this->getState('published', '');
 
-			if ($fltLatest)
+		if ($fltLatest)
 		{
 			$subQuery = $db->getQuery(true)
 				->select($db->qn('r1.id'))
 				->from($db->qn('#__ars_releases') . ' AS ' . $db->qn('r1'))
 				->leftJoin($db->qn('#__ars_releases') . ' AS ' . $db->qn('r2') . ' ON ('.
 					$db->qn('r1.category_id') . ' = ' . $db->qn('r2.category_id') . ' AND ' .
-					$db->qn('r1.ordering') . ' > ' . $db->qn('r2.ordering')
+					$db->qn('r1.ordering') . ' > ' . $db->qn('r2.ordering') .
+					($fltPublished !== '' ? (' AND ' . $db->qn('r2.published') . ' = ' . $db->q($fltPublished)) : '')
 					.')')
 				->where($db->qn('r2.ordering') . ' IS NULL');
 


### PR DESCRIPTION
When filtering for the latest release in a category, if the published filter is also given (`arslatest` content plugin or Latest Releases view), then the filter needs to also account for the published state otherwise if the latest release is an unpublished release then there will be no data returned.  With the `arslatest` plugin, any references to a specific category end up showing nothing and on the Latest Releases view the latest release for a category just doesn't show up at all.