### PR TITLE
Wrap the signatures

### DIFF
--- a/component/media/css/frontend.css
+++ b/component/media/css/frontend.css
@@ -36,3 +36,9 @@ div[class^="ars-release"] h4 a{text-decoration: none;}
 div[class^="ars-category"] h4 {padding-bottom: 10px}
 div[class^="ars-category"] h4 a{text-decoration: none}
 div[class^="ars-item"] h4 a{text-decoration: none}
+
+
+.ars-release-properties td:nth-child(2) {
+	word-break: break-all;
+	word-wrap: break-word;
+}


### PR DESCRIPTION
On small screens, there is a horizontal scrollbar because of the signatures. They can be wrapped. 

![image](https://user-images.githubusercontent.com/251072/44159231-17968580-a0b7-11e8-8e6c-2d7b5dd52c90.png)

Not sure if it is the right place to put the code.