### PR TITLE
Fix invalid markup and give a proper id for releases

### DIFF
--- a/component/frontend/ViewTemplates/Releases/release.blade.php
+++ b/component/frontend/ViewTemplates/Releases/release.blade.php
@@ -94,7 +94,7 @@ $environments = ($this->params->get('show_environments', 1) == 1) ? $this->getEn
             @endif
         </table>
 
-        <div id=reltabs-{{ $item->id }}-notes"">
+        <div id="ars-release-{{{ $item->id }}}-notes">
             <h3>
                 @lang('COM_ARS_RELEASE_NOTES_LABEL')
             </h3>


### PR DESCRIPTION
There is a double quote after the id attribute  which makes the output invalid HTML. I guess the reltabs is a leftover from version 4. So I propose to use a similar pattern as for the release info element.