### PR TITLE
Correct variables for plural hits

### DIFF
--- a/component/frontend/tmpl/releases/release.php
+++ b/component/frontend/tmpl/releases/release.php
@@ -104,7 +104,7 @@ HTMLHelper::_('bootstrap.collapse', '.ars-collapse');
 				<?php if ($this->params->get('show_downloads', 1)): ?>
 					<tr>
 						<td><?= Text::_('COM_ARS_RELEASE_LBL_HITS') ?></td>
-						<td><?= Text::sprintf(($item->hits == 1 ? 'COM_ARS_RELEASE_LBL_TIME' : 'COM_ARS_RELEASE_LBL_TIMES'), $item->hits) ?></td>
+						<td><?= Text::sprintf(($item->hits == 1 ? 'COM_ARS_RELEASE_LBL_TIME_1' : 'COM_ARS_RELEASE_LBL_TIME'), $item->hits) ?></td>
 					</tr>
 				<?php endif ?>
 			</table>


### PR DESCRIPTION
There is no language string COM_ARS_RELEASE_LBL_TIMES, only COM_ARS_RELEASE_LBL_TIME and COM_ARS_RELEASE_LBL_TIME_1.