### PR TITLE
Use date HTMLHelper service

### DIFF
--- a/component/backend/tmpl/logs/default.php
+++ b/component/backend/tmpl/logs/default.php
@@ -154,7 +154,7 @@ $userLayout = new FileLayout('akeeba.ars.common.user', JPATH_ADMINISTRATOR . '/c
 
 								<td>
 									<div class="fw-bold">
-										<?= HTMLHelper::_('ars.formatDate', $item->accessed_on, true) ?>
+										<?= HTMLHelper::_('date', $item->accessed_on, true) ?>
 									</div>
 									<div class="text-monospace text-success my-1">
 										<?= $this->escape($item->ip) ?>

--- a/component/backend/tmpl/releases/default.php
+++ b/component/backend/tmpl/releases/default.php
@@ -168,7 +168,7 @@ $cParams = ComponentHelper::getParams('com_ars');
 								</td>
 
 								<td>
-									<?= HTMLHelper::_('ars.formatDate', $item->created) ?>
+									<?= HTMLHelper::_('date', $item->created) ?>
 								</td>
 
 								<td class="d-none d-md-table-cell">

--- a/component/frontend/tmpl/items/release.php
+++ b/component/frontend/tmpl/items/release.php
@@ -57,7 +57,7 @@ switch ($item->maturity)
 	<div class="text-muted d-flex mb-2">
 		<div class="flex-grow-1">
 			<strong><?= Text::_('COM_ARS_RELEASE_LBL_RELEASEDON') ?></strong>:
-			<?= HTMLHelper::_('ars.formatDate', $item->created, Text::_('DATE_FORMAT_LC2')) ?>
+			<?= HTMLHelper::_('date', $item->created, Text::_('DATE_FORMAT_LC2')) ?>
 		</div>
 		<div>
 			<button class="btn btn-dark btn-sm release-info-toggler" type="button"

--- a/component/frontend/tmpl/releases/release.php
+++ b/component/frontend/tmpl/releases/release.php
@@ -66,7 +66,7 @@ HTMLHelper::_('bootstrap.collapse', '.ars-collapse');
 	<div class="d-flex">
 		<div class="flex-grow-1">
 			<strong><?= Text::_('COM_ARS_RELEASE_LBL_RELEASEDON') ?></strong>:
-			<?= HTMLHelper::_('ars.formatDate', $item->created, Text::_('DATE_FORMAT_LC1')) ?>
+			<?= HTMLHelper::_('date', $item->created, Text::_('DATE_FORMAT_LC1')) ?>
 		</div>
 		<div>
 			<button class="btn btn-dark btn-sm release-info-toggler" type="button"
@@ -98,7 +98,7 @@ HTMLHelper::_('bootstrap.collapse', '.ars-collapse');
 						<?= Text::_('COM_ARS_RELEASE_LBL_RELEASEDON') ?>
 					</td>
 					<td>
-						<?= HTMLHelper::_('ars.formatDate', $item->created, Text::_('DATE_FORMAT_LC1')) ?>
+						<?= HTMLHelper::_('date', $item->created, Text::_('DATE_FORMAT_LC1')) ?>
 					</td>
 				</tr>
 				<?php if ($this->params->get('show_downloads', 1)): ?>


### PR DESCRIPTION
I couldn't find the ARS date helper, so not sure if it still exists and I can't find it. But the code prints always the raw SQL date, so I would suggest to go with core date instead.