### PR TITLE
Environments should be loaded without state

### DIFF
--- a/component/backend/src/Model/ReleasesModel.php
+++ b/component/backend/src/Model/ReleasesModel.php
@@ -125,7 +125,7 @@ class ReleasesModel extends ListModel
 		$ret = [];
 
 		/** @var ItemsModel $itemsModel */
-		$itemsModel = $this->getMVCFactory()->createModel('Items', 'Administrator');
+		$itemsModel = $this->getMVCFactory()->createModel('Items', 'Administrator', ['ignore_request' => true]);
 		$itemsModel->setState('filter.release_id', $release->id);
 		$items = $itemsModel->getItems();
 


### PR DESCRIPTION
On releases are always all environments loaded. This happens because the environments model overloads the internal state.