### PR TITLE
Update LoadAnyTemplate.php

### DIFF
--- a/component/backend/src/Mixin/LoadAnyTemplate.php
+++ b/component/backend/src/Mixin/LoadAnyTemplate.php
@@ -94,7 +94,7 @@ trait LoadAnyTemplate
 			// Apply the new base layout
 			$this->setLayout($layout);
 			// Get the subtemplate (null here means load the base layout file)
-			$ret = $this->loadTemplate($tpl, false, $extraVariables);
+			$ret = $this->loadATemplate($tpl, false, $extraVariables);
 		}
 		catch (Throwable $e)
 		{
@@ -158,7 +158,7 @@ HTML;
 	 * @throws Exception
 	 * @since   9.0.0
 	 */
-	public function loadTemplate($tpl = null, bool $fallbackToDefault = true, array $extraVariables = []): string
+	public function loadATemplate($tpl = null, bool $fallbackToDefault = true, array $extraVariables = []): string
 	{
 		// Clear prior output
 		$this->_output = null;


### PR DESCRIPTION
As some page builders like YOOtheme Pro also use the public function loadTemplate() I propose to rename this function in order to not interfere.

Without renaming any ARS frontend view results in this fatal error:
```
Fatal error: Declaration of YOOtheme\Theme\Joomla\ViewTrait::loadTemplate($tpl = NULL) must be compatible with Akeeba\Component\ARS\Site\View\Items\HtmlView::loadTemplate($tpl = NULL, bool $fallbackToDefault = true, array $extraVariables = Array): string in /var/www/virtual/ruhepotential.de/rp4x_ruhepotential_de/htdocs/templates/yootheme/vendor/yootheme/theme-joomla/src/ViewsObject.php(52) : eval()'d code on line 16
```