### PR TITLE
Update Common.php

### DIFF
--- a/component/frontend/src/View/Update/Common.php
+++ b/component/frontend/src/View/Update/Common.php
@@ -93,7 +93,7 @@ trait Common
 		}
 
 		$downloadURL = Route::_(sprintf(
-			"index.php?option=com_ars&view=item&format=%s&category_id=%d&release_id=%d&item_id=%d%s",
+			"index.php?option=com_ars&view=item&format=%s&category_id=%d&release_id=%d&item_id=%d%s&Itemid=50",
 			$format, $item->category, $item->release_id, $item->item_id, $this->dlidRequest
 		),
 			true, Route::TLS_IGNORE, true);


### PR DESCRIPTION
Currently `<downloadurl>` in XML Updatestreams will be SEF-formatted like this: `https://domain.tld/component/ars/item/item-alias.zip?category_id=1&release_id=1`.

As soon as `Itemid` of the entire repository will be added to `$downloadURL` in Common.php, `<downloadurl>` in XML Updatestreams will be SEF-formatted as expected, for example `https://domain.tld/download/category-alias/release-alias/item-alias.zip`.

Do you, Nicholas, or does somebody have an idea or a hint which file has to be modified in order to tell the router the respository's current `Itemid'?

It seems that formerly `Akeeba\ReleaseSystem\Site\Helper\Router` was replaced by core `Joomla\CMS\Router\Route`, so I have no idea which file suits best to store the Itemid...

Thank you for paying attention to it :-)