### PR TITLE
Add access property to automatic item descriptions

### DIFF
--- a/component/backend/forms/autodescription.xml
+++ b/component/backend/forms/autodescription.xml
@@ -42,6 +42,16 @@
         />
 
         <field
+                name="access"
+                type="accesslevel"
+                label="JFIELD_ACCESS_LABEL"
+                filter="UINT"
+                validate="options"
+        >
+            <option></option>
+        </field>
+
+        <field
                 name="description"
                 type="editor"
                 label="COM_ARS_AUTODESCRIPTION_FIELD_DESCRIPTION"

--- a/component/backend/sql/install.mysql.utf8.sql
+++ b/component/backend/sql/install.mysql.utf8.sql
@@ -132,6 +132,7 @@ CREATE TABLE IF NOT EXISTS `#__ars_autoitemdesc` (
     `category`         bigint(20) unsigned NOT NULL,
     `packname`         varchar(255)                 DEFAULT NULL,
     `title`            varchar(255)        NOT NULL,
+    `access`           int(11)             NOT NULL DEFAULT '0',
     `description`      MEDIUMTEXT          NOT NULL,
     `environments`     varchar(100)                 DEFAULT NULL,
     `created`          datetime            NULL     DEFAULT NULL,

--- a/component/backend/sql/updates/mysql/7.1.0-20220922.sql
+++ b/component/backend/sql/updates/mysql/7.1.0-20220922.sql
@@ -1,0 +1,7 @@
+/**
+ * @package   AkeebaReleaseSystem
+ * @copyright Copyright (c)2010-2022 Nicholas K. Dionysopoulos / Akeeba Ltd
+ * @license   GNU General Public License version 3, or later
+ */
+
+ALTER TABLE `#__ars_autoitemdesc` ADD `access` INT(11) NOT NULL DEFAULT '0' AFTER `title`;

--- a/component/backend/src/Table/ItemTable.php
+++ b/component/backend/src/Table/ItemTable.php
@@ -295,6 +295,9 @@ class ItemTable extends AbstractTable
 		// Apply title
 		$this->title = trim($this->title ?? '') ?: $auto->title;
 
+		// Apply access
+		$this->access = $this->access !== 1 || !$auto->access ? $this->access : $auto->access ;
+
 		// Apply description, if necessary
 		$stripDesc = trim(strip_tags($this->description));
 

--- a/component/backend/tmpl/autodescription/edit.php
+++ b/component/backend/tmpl/autodescription/edit.php
@@ -32,6 +32,7 @@ $user = Factory::getApplication()->getIdentity();
 					<?= $this->form->getField('category')->renderField(); ?>
 					<?= $this->form->getField('packname')->renderField(); ?>
 					<?= $this->form->getField('title')->renderField(); ?>
+					<?= $this->form->getField('access')->renderField(); ?>
 					<?= $this->form->getField('environments')->renderField(); ?>
 					<?= $this->form->getField('published')->renderField(); ?>
 				</div>


### PR DESCRIPTION
Adds a new access level property for automatic item descriptions. Initially it has no value, so it doesn't change the existing behavior.

Closes #213 