### PR TITLE
Fix the delete action button on the "Download Logs" page

### DIFF
--- a/component/backend/src/View/Logs/HtmlView.php
+++ b/component/backend/src/View/Logs/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
 
 		if ($user->authorise('core.delete', 'com_ars'))
 		{
-			$toolbar->delete('releases.delete')
+			$toolbar->delete('logs.delete')
 				->message('JGLOBAL_CONFIRM_DELETE')
 				->listCheck(true);
 		}


### PR DESCRIPTION
Currently the delete action button on the "Download Page" is not working.