### PR TITLE
Add hits column with sorting on the items page (back-end)

### DIFF
--- a/component/backend/forms/filter_items.xml
+++ b/component/backend/forms/filter_items.xml
@@ -93,6 +93,8 @@
             <option value="i.title DESC">JGLOBAL_TITLE_DESC</option>
             <option value="i.id ASC">JGRID_HEADING_ID_ASC</option>
             <option value="i.id DESC">JGRID_HEADING_ID_DESC</option>
+			<option value="i.hits ASC">JGLOBAL_HITS_ASC</option>
+            <option value="i.hits DESC">JGLOBAL_HITS_DESC</option>
             <option value="i.access ASC">JGRID_HEADING_ACCESS_ASC</option>
             <option value="i.access DESC">JGRID_HEADING_ACCESS_DESC</option>
             <option value="i.language ASC">JGRID_HEADING_LANGUAGE_ASC</option>

--- a/component/backend/forms/item.xml
+++ b/component/backend/forms/item.xml
@@ -228,6 +228,7 @@
         <field
                 name="hits"
                 type="number"
+		default="0"
                 label="JGLOBAL_HITS"
                 class="readonly"
                 readonly="true"

--- a/component/backend/src/Model/ItemsModel.php
+++ b/component/backend/src/Model/ItemsModel.php
@@ -29,6 +29,7 @@ class ItemsModel extends ListModel
 			$config['filter_fields'] = [
 				'search',
 				'id', 'i.id',
+				'hits', 'i.hits',
 				'release_id', 'i.release_id',
 				'category_id', 'c.id',
 				'title', 'i.title',

--- a/component/backend/src/View/Logs/HtmlView.php
+++ b/component/backend/src/View/Logs/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
 
 		if ($user->authorise('core.delete', 'com_ars'))
 		{
-			$toolbar->delete('releases.delete')
+			$toolbar->delete('logs.delete')
 				->message('JGLOBAL_CONFIRM_DELETE')
 				->listCheck(true);
 		}

--- a/component/backend/tmpl/items/default.php
+++ b/component/backend/tmpl/items/default.php
@@ -101,12 +101,15 @@ else
 							<th scope="col" class="d-none d-md-table-cell">
 								<?= HTMLHelper::_('searchtools.sort', 'JFIELD_ACCESS_LABEL', 'i.access', $listDirn, $listOrder); ?>
 							</th>
+							<th scope="col" class="w-1 d-none d-md-table-cell">
+								<?= HTMLHelper::_('searchtools.sort', 'COM_ARS_ITEM_FIELD_HITS', 'i.hits', $listDirn, $listOrder); ?>
+							</th>
 							<?php if (Multilanguage::isEnabled()) : ?>
 								<th scope="col">
 									<?= HTMLHelper::_('searchtools.sort', 'JFIELD_LANGUAGE_LABEL', 'i.language', $listDirn, $listOrder); ?>
 								</th>
 							<?php endif; ?>
-							<th scope="col">
+							<th scope="col" class="text-center">
 								<?= Text::_('JPUBLISHED') ?>
 							</th>
 							<th scope="col" class="w-1 d-none d-md-table-cell">
@@ -224,6 +227,10 @@ else
 										<?= LayoutHelper::render('joomla.content.language', $item); ?>
 									</td>
 								<?php endif; ?>
+								
+								<td class="w-1 d-none d-md-table-cell">
+									<?= $item->hits ?>
+								</td>
 
 								<td class="text-center">
 									<?= HTMLHelper::_('jgrid.published', $item->published, $i, 'items.', $user->authorise('core.edit.state', 'com_ars'), 'cb'); ?>


### PR DESCRIPTION
Here is very useful feature since we have only total download statistic. The PR will add an extra hits/downloads count column on the items page for the back-end users, to monitor download statistic per software item.

Hope you will find it useful.

Best regards
Anatoliy Kulbabskyy