### PR TITLE
Update Router.php

### DIFF
--- a/component/frontend/src/Service/Router.php
+++ b/component/frontend/src/Service/Router.php
@@ -176,7 +176,7 @@ class Router extends RouterView
 		 */
 
 		$unsetItemIdCorrect = $queryItemId == $defaultItemid ||
-			($queryItemId == $currentItemid && $currentComponent !== 'com_ars');
+			($queryItemId !== $currentItemid && $currentComponent == 'com_ars');
 		$unsetItemIdWrong   = $queryItemId == $defaultItemid || $queryItemId == $currentItemid;
 
 		$unsetItemId = (ComponentHelper::getParams('com_ars')->get('router_itemid_behaviour', '0') == 0)


### PR DESCRIPTION
When setting "Use ItemID to build SEF URLs" to yes the frontend SEF routing is still broken. It seems there is something wrong with `$unsetItemIdCorrect`. I suppose the second check inside braces was intended to be different.

Why would you check for `com_ars` NOT to be present?