### PR TITLE
Add show unauthorized links options to automatic item description

### DIFF
--- a/component/backend/forms/autodescription.xml
+++ b/component/backend/forms/autodescription.xml
@@ -52,6 +52,26 @@
         </field>
 
         <field
+                name="show_unauth_links"
+                type="list"
+                layout="joomla.form.field.radio.switcher"
+                label="COM_ARS_COMMON_SHOW_UNAUTH_LINKS"
+                default="0"
+                validate="options"
+        >
+            <option value="0">JNO</option>
+            <option value="1">JYES</option>
+        </field>
+
+        <field
+                name="redirect_unauth"
+                type="url"
+                label="COM_ARS_COMMON_REDIRECT_UNAUTH"
+                validate="url"
+                showon="show_unauth_links:1"
+        />
+
+        <field
                 name="description"
                 type="editor"
                 label="COM_ARS_AUTODESCRIPTION_FIELD_DESCRIPTION"

--- a/component/backend/sql/install.mysql.utf8.sql
+++ b/component/backend/sql/install.mysql.utf8.sql
@@ -128,20 +128,22 @@ CREATE TABLE IF NOT EXISTS `#__ars_updatestreams` (
 ) ENGINE InnoDB DEFAULT CHARSET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `#__ars_autoitemdesc` (
-    `id`               bigint(20)          NOT NULL AUTO_INCREMENT,
-    `category`         bigint(20) unsigned NOT NULL,
-    `packname`         varchar(255)                 DEFAULT NULL,
-    `title`            varchar(255)        NOT NULL,
-    `access`           int(11)             NOT NULL DEFAULT '0',
-    `description`      MEDIUMTEXT          NOT NULL,
-    `environments`     varchar(100)                 DEFAULT NULL,
-    `created`          datetime            NULL     DEFAULT NULL,
-    `created_by`       int(11)             NOT NULL DEFAULT '0',
-    `modified`         datetime            NULL     DEFAULT NULL,
-    `modified_by`      int(11)             NOT NULL DEFAULT '0',
-    `checked_out`      int(11)             NOT NULL DEFAULT '0',
-    `checked_out_time` datetime            NULL     DEFAULT NULL,
-    `published`        int(11)             NOT NULL DEFAULT '1',
+    `id`                bigint(20)          NOT NULL AUTO_INCREMENT,
+    `category`          bigint(20) unsigned NOT NULL,
+    `packname`          varchar(255)                 DEFAULT NULL,
+    `title`             varchar(255)        NOT NULL,
+    `access`            int(11)             NOT NULL DEFAULT '0',
+    `show_unauth_links` tinyint             NOT NULL DEFAULT '0',
+    `redirect_unauth`   varchar(255)        NOT NULL DEFAULT '',
+    `description`       MEDIUMTEXT          NOT NULL,
+    `environments`      varchar(100)                 DEFAULT NULL,
+    `created`           datetime            NULL     DEFAULT NULL,
+    `created_by`        int(11)             NOT NULL DEFAULT '0',
+    `modified`          datetime            NULL     DEFAULT NULL,
+    `modified_by`       int(11)             NOT NULL DEFAULT '0',
+    `checked_out`       int(11)             NOT NULL DEFAULT '0',
+    `checked_out_time`  datetime            NULL     DEFAULT NULL,
+    `published`         int(11)             NOT NULL DEFAULT '1',
     PRIMARY KEY `id` (`id`)
 ) ENGINE InnoDB DEFAULT CHARSET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
 

--- a/component/backend/sql/updates/mysql/7.2.0-20221230.sql
+++ b/component/backend/sql/updates/mysql/7.2.0-20221230.sql
@@ -1,0 +1,8 @@
+/**
+ * @package   AkeebaReleaseSystem
+ * @copyright Copyright (c)2010-2022 Nicholas K. Dionysopoulos / Akeeba Ltd
+ * @license   GNU General Public License version 3, or later
+ */
+
+ALTER TABLE `#__ars_autoitemdesc` ADD `show_unauth_links` TINYINT NOT NULL DEFAULT '0' AFTER `access`;
+ALTER TABLE `#__ars_autoitemdesc` ADD `redirect_unauth` VARCHAR(255) NOT NULL DEFAULT '' AFTER `show_unauth_links`;

--- a/component/backend/src/Table/ItemTable.php
+++ b/component/backend/src/Table/ItemTable.php
@@ -298,6 +298,10 @@ class ItemTable extends AbstractTable
 		// Apply access
 		$this->access = $this->access !== 1 || !$auto->access ? $this->access : $auto->access ;
 
+        // Apply unauthorized links
+		$this->show_unauth_links = $this->show_unauth_links == 1 || !$auto->show_unauth_links ? $this->show_unauth_links : $auto->show_unauth_links ;
+		$this->redirect_unauth   = $this->redirect_unauth ?: $auto->redirect_unauth ;
+
 		// Apply description, if necessary
 		$stripDesc = trim(strip_tags($this->description));
 

--- a/component/backend/tmpl/autodescription/edit.php
+++ b/component/backend/tmpl/autodescription/edit.php
@@ -33,6 +33,8 @@ $user = Factory::getApplication()->getIdentity();
 					<?= $this->form->getField('packname')->renderField(); ?>
 					<?= $this->form->getField('title')->renderField(); ?>
 					<?= $this->form->getField('access')->renderField(); ?>
+					<?= $this->form->getField('show_unauth_links')->renderField(); ?>
+					<?= $this->form->getField('redirect_unauth')->renderField(); ?>
 					<?= $this->form->getField('environments')->renderField(); ?>
 					<?= $this->form->getField('published')->renderField(); ?>
 				</div>


### PR DESCRIPTION
Adds the show unauthorized options to the automatic item description. With the current implementation when show unauth is enabled in the automatic item description and an item is saved with it disabled, then it gets enabled, even the setting is disabled in the item.