### PR TITLE
Fix SEF issue on list views when items have their own menu item

### DIFF
--- a/component/backend/src/Model/UpgradeModel.php
+++ b/component/backend/src/Model/UpgradeModel.php
@@ -470,6 +470,8 @@ class UpgradeModel extends BaseModel implements DatabaseAwareInterface
                             $uri->setVar('category', $params['category']);
                             unset($params['category']);
                             break;
+                        default:
+                            continue 3;
                     }
                     break;
             }

--- a/component/backend/src/Model/UpgradeModel.php
+++ b/component/backend/src/Model/UpgradeModel.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Installer\Adapter\PackageAdapter;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\MVC\Model\BaseModel;
 use Joomla\CMS\Table\Extension;
+use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseAwareTrait;
@@ -234,6 +235,7 @@ class UpgradeModel extends BaseModel implements DatabaseAwareInterface
 					'uninstallExtensions',
 					'uninstallProExtensions',
 					'adoptMyExtensions',
+					'updateMenuLinks',
 				]);
 
 				$this->runCustomHandlerEvent('onUpdate', $type, $parent);
@@ -385,6 +387,102 @@ class UpgradeModel extends BaseModel implements DatabaseAwareInterface
 			->bind(':package_id', $newPackageId, ParameterType::INTEGER);
 		$db->setQuery($query)->execute();
 	}
+
+    /**
+     * Update existing menu links
+     *
+     * In previous versions the item ID of menu items for releases, items and update feeds was not part of the link but
+     * included in the params json. This caused issues with SEF routing where multiple items on the same page received
+     * the same link because all menu links appeared to be identical. This function moves the item ID from the params
+     * json to the link in #__menu table.
+     *
+     * @return  void
+     */
+    public function updateMenuLinks(): void
+    {
+        $db = $this->getDatabase();
+
+        // get affected menu items
+        $query = $db->getQuery(true)
+            ->select($db->qn(['m.id', 'm.link', 'm.params']))
+            ->from($db->qn('#__menu') . ' AS m')
+            ->join('INNER', $db->qn('#__extensions') . ' AS e ON (' . $db->qn('e.extension_id') . ' = ' . $db->qn('m.component_id') . ')')
+            ->where($db->qn('m.client_id') . ' = ' . $db->q(0))
+            ->where($db->qn('e.type') . ' = ' . $db->q('component'))
+            ->where($db->qn('e.element') . ' = ' . $db->q('com_ars'));
+        $menuItems = $db->setQuery($query)->loadObjectList();
+
+        if (empty($menuItems))
+        {
+            return;
+        }
+
+        foreach ($menuItems as $menuItem)
+        {
+            // load Uri object and parse link
+            $uri = new Uri;
+            $uri->parse($menuItem->link);
+
+            // only process views, which link to a particular item
+            if (!in_array($uri->getVar('view'), ['releases', 'items', 'update']))
+            {
+                continue;
+            }
+
+            $params = json_decode($menuItem->params, true);
+
+            // move item ID from params to link
+            switch ($uri->getVar('view'))
+            {
+                case 'releases':
+                    if ($uri->getVar('category_id') || empty($params['category_id']))
+                    {
+                        continue 2;
+                    }
+                    $uri->setVar('category_id', $params['category_id']);
+                    unset($params['category_id']);
+                    break;
+                case 'items':
+                    if ($uri->getVar('release_id') || empty($params['release_id']))
+                    {
+                        continue 2;
+                    }
+                    $uri->setVar('release_id', $params['release_id']);
+                    unset($params['release_id']);
+                    break;
+                case 'update':
+                    switch ($uri->getVar('layout'))
+                    {
+                        case 'ini':
+                        case 'stream':
+                            if ($uri->getVar('stream_id') || empty($params['stream_id']))
+                            {
+                                continue 3;
+                            }
+                            $uri->setVar('stream_id', $params['stream_id']);
+                            unset($params['stream_id']);
+                            break;
+                        case 'category':
+                            if ($uri->getVar('category') || empty($params['category']))
+                            {
+                                continue 3;
+                            }
+                            $uri->setVar('category', $params['category']);
+                            unset($params['category']);
+                            break;
+                    }
+                    break;
+            }
+
+            // write updated data back to menu table
+            $query = $db->getQuery(true)
+                ->update($db->qn('#__menu'))
+                ->set($db->qn('link') . ' = ' . $db->q($uri->toString()))
+                ->set($db->qn('params') . ' = ' . $db->q(json_encode($params)))
+                ->where($db->qn('id') . ' = ' . $db->q($menuItem->id));
+            $db->setQuery($query)->execute();
+        }
+    }
 
 	/**
 	 * Handle the package upgrade from the old to the new package.

--- a/component/frontend/tmpl/items/default.xml
+++ b/component/frontend/tmpl/items/default.xml
@@ -12,8 +12,10 @@
         </message>
     </layout>
 
-    <fields name="params" addfieldprefix="Akeeba\Component\ARS\Administrator\Field">
-        <fieldset name="basic" label="COM_ARS_FIELDSET_BASIC">
+    <fields name="request">
+        <fieldset name="request"
+                  addfieldprefix="Akeeba\Component\ARS\Administrator\Field" >
+
             <field
                     name="release_id"
                     type="ArsReleases"
@@ -24,7 +26,11 @@
             >
                 <option value="">COM_ARS_COMMON_RELEASE_SELECT_LABEL</option>
             </field>
+        </fieldset>
+    </fields>
 
+    <fields name="params" addfieldprefix="Akeeba\Component\ARS\Administrator\Field">
+        <fieldset name="advanced" label="COM_ARS_FIELDSET_ADVANCED">
             <field
                     name="items_orderby"
                     type="list"
@@ -39,8 +45,7 @@
                 <option value="rcreated">COM_ARS_BROWSE_REPOSITORY_ORDERBY_RCREATED</option>
                 <option value="order">COM_ARS_BROWSE_REPOSITORY_ORDERBY_ORDER</option>
             </field>
-        </fieldset>
-        <fieldset name="advanced" label="COM_ARS_FIELDSET_ADVANCED">
+
             <field name="show_pagination" type="list" default="2" label="JGLOBAL_PAGINATION_LABEL"
             >
                 <option value="0">JHide</option>

--- a/component/frontend/tmpl/items/default.xml
+++ b/component/frontend/tmpl/items/default.xml
@@ -30,7 +30,8 @@
     </fields>
 
     <fields name="params" addfieldprefix="Akeeba\Component\ARS\Administrator\Field">
-        <fieldset name="advanced" label="COM_ARS_FIELDSET_ADVANCED">
+        <fieldset name="basic" label="COM_ARS_FIELDSET_BASIC">
+
             <field
                     name="items_orderby"
                     type="list"
@@ -45,7 +46,9 @@
                 <option value="rcreated">COM_ARS_BROWSE_REPOSITORY_ORDERBY_RCREATED</option>
                 <option value="order">COM_ARS_BROWSE_REPOSITORY_ORDERBY_ORDER</option>
             </field>
+        </fieldset>
 
+        <fieldset name="advanced" label="COM_ARS_FIELDSET_ADVANCED">
             <field name="show_pagination" type="list" default="2" label="JGLOBAL_PAGINATION_LABEL"
             >
                 <option value="0">JHide</option>

--- a/component/frontend/tmpl/releases/default.xml
+++ b/component/frontend/tmpl/releases/default.xml
@@ -11,8 +11,10 @@
             <![CDATA[COM_ARS_VIEW_CATEGORY_DESC]]>
         </message>
     </layout>
-    <fields name="params" addfieldprefix="Akeeba\Component\ARS\Administrator\Field">
-        <fieldset name="basic" label="COM_ARS_FIELDSET_BASIC">
+    <fields name="request">
+        <fieldset name="request"
+                  addfieldprefix="Akeeba\Component\ARS\Administrator\Field" >
+
             <field
                     name="category_id"
                     type="ArsCategories"
@@ -21,7 +23,10 @@
             >
                 <option value="">COM_ARS_COMMON_CATEGORY_SELECT_LABEL</option>
             </field>
-
+        </fieldset>
+    </fields>
+    <fields name="params" addfieldprefix="Akeeba\Component\ARS\Administrator\Field">
+        <fieldset name="basic" label="COM_ARS_FIELDSET_BASIC">
             <field
                     name="rel_orderby"
                     type="list"
@@ -52,6 +57,7 @@
                 <option value="order">COM_ARS_BROWSE_REPOSITORY_ORDERBY_ORDER</option>
             </field>
         </fieldset>
+
         <fieldset name="advanced" label="COM_ARS_FIELDSET_ADVANCED">
             <field
                     name="show_pagination"

--- a/component/frontend/tmpl/update/category.xml
+++ b/component/frontend/tmpl/update/category.xml
@@ -11,10 +11,10 @@
             <![CDATA[COM_ARS_VIEW_UPDATE_CATEGORY_DESC]]>
         </message>
     </layout>
-    <fields name="params">
-        <fieldset name="basic" label="COM_ARS_FIELDSET_BASIC">
+    <fields name="request">
+        <fieldset name="request">
             <field name="category" type="list" default="components" label="COM_ARS_UPDATESTREAM_CATEGORY_TITLE"
-                   description="COM_ARS_UPDATESTREAM_CATEGORY_DESC">
+                   description="COM_ARS_UPDATESTREAM_CATEGORY_DESC" required="true">
                 <option value="components">COM_ARS_UPDATESTREAM_UPDATETYPE_COMPONENTS</option>
                 <option value="libraries">COM_ARS_UPDATESTREAM_UPDATETYPE_LIBRARIES</option>
                 <option value="modules">COM_ARS_UPDATESTREAM_UPDATETYPE_MODULES</option>
@@ -23,10 +23,7 @@
                 <option value="files">COM_ARS_UPDATESTREAM_UPDATETYPE_FILES</option>
                 <option value="templates">COM_ARS_UPDATESTREAM_UPDATETYPE_TEMPLATES</option>
             </field>
-        </fieldset>
-    </fields>
-    <fields name="request">
-        <fieldset name="request">
+
             <field name="format"
                    type="hidden"
                    default="xml"

--- a/component/frontend/tmpl/update/ini.xml
+++ b/component/frontend/tmpl/update/ini.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--~
   ~ @package   AkeebaReleaseSystem
-  ~ @copyright Copyright (c)2010-2024 Nicholas K. Dionysopoulos / Akeeba Ltd
+  ~ @copyright Copyright (c)2010-2023 Nicholas K. Dionysopoulos / Akeeba Ltd
   ~ @license   GNU General Public License version 3, or later
   -->
 
@@ -11,14 +11,11 @@
             <![CDATA[COM_ARS_VIEW_UPDATE_INI_DESC]]>
         </message>
     </layout>
-    <fields name="params">
-        <fieldset name="basic" label="COM_ARS_FIELDSET_BASIC">
-            <field name="stream_id" type="sql" default="0" label="COM_ARS_ITEM_FIELD_UPDATESTREAM" description=""
-                   query="SELECT `id`, `name` FROM `#__ars_updatestreams`" key_field="id" value_field="name"/>
-        </fieldset>
-    </fields>
     <fields name="request">
         <fieldset name="request">
+            <field name="stream_id" type="sql" default="0" label="COM_ARS_ITEM_FIELD_UPDATESTREAM" description=""
+                   query="SELECT `id`, `name` FROM `#__ars_updatestreams`" key_field="id" value_field="name" required="true"/>
+
             <field name="format"
                    type="hidden"
                    default="ini"

--- a/component/frontend/tmpl/update/stream.xml
+++ b/component/frontend/tmpl/update/stream.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--~
   ~ @package   AkeebaReleaseSystem
-  ~ @copyright Copyright (c)2010-2024 Nicholas K. Dionysopoulos / Akeeba Ltd
+  ~ @copyright Copyright (c)2010-2023 Nicholas K. Dionysopoulos / Akeeba Ltd
   ~ @license   GNU General Public License version 3, or later
   -->
 
@@ -11,14 +11,11 @@
             <![CDATA[COM_ARS_VIEW_UPDATE_STREAM_DESC]]>
         </message>
     </layout>
-    <fields name="params">
-        <fieldset name="basic" label="COM_ARS_FIELDSET_BASIC">
-            <field name="stream_id" type="sql" default="0" label="COM_ARS_ITEM_FIELD_UPDATESTREAM" description=""
-                   query="SELECT `id`, `name` FROM `#__ars_updatestreams`" key_field="id" value_field="name"/>
-        </fieldset>
-    </fields>
     <fields name="request">
         <fieldset name="request">
+            <field name="stream_id" type="sql" default="0" label="COM_ARS_ITEM_FIELD_UPDATESTREAM" description=""
+                   query="SELECT `id`, `name` FROM `#__ars_updatestreams`" key_field="id" value_field="name" required="true"/>
+
             <field name="format"
                    type="hidden"
                    default="xml"


### PR DESCRIPTION
This fixes the discussion we had about SEF links on category lists: https://github.com/akeeba/release-system/issues/230

I noticed that when creating menu items for releases they all have the same `link` in #__menu table and the category_id is not part of the link but in the params json. This causes the Joomla routing to treat them as identical when looking for existing menu items. The fix is to move the key parameter from the "Basic options" tab to the Details tab ("request" fieldset) and like this the key will become part of the `link`. For example:

before: index.php?option=com_ars&view=releases
after: index.php?option=com_ars&view=releases&category_id=1

I also fixed the same issue on other views (items and updates).

I believe this has no compatibility implications for existing installations. When you save a menu item for the next time the category_id will be moved from params to the link. Values are auto-filled correctly either way and both versions work the same.

