### PR TITLE
Update UpdateController.php

### DIFF
--- a/component/frontend/src/Controller/UpdateController.php
+++ b/component/frontend/src/Controller/UpdateController.php
@@ -99,7 +99,7 @@ class UpdateController extends BaseController
 	 */
 	public function stream(): void
 	{
-		$id = $this->input->getInt('id', 0);
+		$id = $this->input->getInt('stream_id', 0);
 
 		if ($id == 0)
 		{

--- a/component/frontend/src/Controller/UpdateController.php
+++ b/component/frontend/src/Controller/UpdateController.php
@@ -99,7 +99,7 @@ class UpdateController extends BaseController
 	 */
 	public function stream(): void
 	{
-		$id = $this->input->getInt('stream_id', 0);
+		$id = $this->input->getInt('stream_id', 0) ?: $this->input->getInt('id', 0);
 
 		if ($id == 0)
 		{


### PR DESCRIPTION
Dear Nicholas!

After updating from 7.3.2 to 7.4.0, internal links such as `index.php?option=com_ars&view=update&layout=stream&format=xml&stream_id=1` don't work any more.

Assuming that `stream_id` is the latest URL parameter for stream IDs, the only way to get it work, is to change the UpdateController.php like this.

Is this maybe a solution that suits for your project as well?

With regards!