### PR TITLE
Fix BleedingEdge category page hanging for tens of seconds or minutes

### DIFF
--- a/component/backend/sql/install.mysql.utf8.sql
+++ b/component/backend/sql/install.mysql.utf8.sql
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS `#__ars_categories` (
     `published`         int(11)                        NOT NULL DEFAULT '1',
     `is_supported`      TINYINT                        NOT NULL DEFAULT '1',
     `language`          char(7)                        NOT NULL DEFAULT '*',
+    `last_scan`         INT UNSIGNED                   NULL     DEFAULT NULL,
     PRIMARY KEY (`id`),
     KEY `#__ars_categories_published` (`published`)
 ) ENGINE InnoDB DEFAULT CHARSET = utf8mb4 DEFAULT COLLATE = utf8mb4_unicode_ci;
@@ -55,6 +56,7 @@ CREATE TABLE IF NOT EXISTS `#__ars_releases` (
     `redirect_unauth`   VARCHAR(255)                        NOT NULL DEFAULT '',
     `published`         tinyint(1)                          NOT NULL DEFAULT '1',
     `language`          char(7)                             NOT NULL DEFAULT '*',
+    `folder_mtime`      INT UNSIGNED                        NULL     DEFAULT NULL,
     PRIMARY KEY `id` (`id`),
     KEY `#__ars_releases_category_id` (`category_id`),
     KEY `#__ars_releases_published` (`published`)

--- a/component/backend/sql/install.postgresql.utf8.sql
+++ b/component/backend/sql/install.postgresql.utf8.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS "#__ars_categories"
     "published"         INTEGER      NOT NULL DEFAULT 1,
     "is_supported"      SMALLINT     NOT NULL DEFAULT 1,
     "language"          CHAR(7)      NOT NULL DEFAULT '*',
+    "last_scan"         INTEGER               DEFAULT NULL,
     PRIMARY KEY ("id")
 );
 
@@ -52,6 +53,7 @@ CREATE TABLE IF NOT EXISTS "#__ars_releases"
     "redirect_unauth"   VARCHAR(255) NOT NULL DEFAULT '',
     "published"         SMALLINT     NOT NULL DEFAULT 1,
     "language"          CHAR(7)      NOT NULL DEFAULT '*',
+    "folder_mtime"      INTEGER               DEFAULT NULL,
     PRIMARY KEY ("id")
 );
 

--- a/component/backend/sql/updates/mysql/7.4.4.sql
+++ b/component/backend/sql/updates/mysql/7.4.4.sql
@@ -1,0 +1,15 @@
+/**
+ * @package   AkeebaReleaseSystem
+ * @copyright Copyright (c)2026 Nicholas K. Dionysopoulos / Akeeba Ltd
+ * @license   GNU General Public License version 3, or later
+ */
+
+-- Track the filemtime() of the category folder at the time of last scan.
+-- NULL means the category has never been scanned, forcing a full scan on first page load.
+ALTER TABLE `#__ars_categories`
+    ADD COLUMN `last_scan` INT UNSIGNED NULL DEFAULT NULL;
+
+-- Track the filemtime() of each release folder at the time of last checkFiles() run.
+-- NULL means the release has never been scanned, forcing checkFiles() on first page load.
+ALTER TABLE `#__ars_releases`
+    ADD COLUMN `folder_mtime` INT UNSIGNED NULL DEFAULT NULL;

--- a/component/backend/sql/updates/postgresql/7.4.4.sql
+++ b/component/backend/sql/updates/postgresql/7.4.4.sql
@@ -1,0 +1,15 @@
+/**
+ * @package   AkeebaReleaseSystem
+ * @copyright Copyright (c)2026 Nicholas K. Dionysopoulos / Akeeba Ltd
+ * @license   GNU General Public License version 3, or later
+ */
+
+-- Track the filemtime() of the category folder at the time of last scan.
+-- NULL means the category has never been scanned, forcing a full scan on first page load.
+ALTER TABLE "#__ars_categories"
+    ADD COLUMN "last_scan" INTEGER DEFAULT NULL;
+
+-- Track the filemtime() of each release folder at the time of last checkFiles() run.
+-- NULL means the release has never been scanned, forcing checkFiles() on first page load.
+ALTER TABLE "#__ars_releases"
+    ADD COLUMN "folder_mtime" INTEGER DEFAULT NULL;

--- a/component/frontend/src/Model/BleedingedgeModel.php
+++ b/component/frontend/src/Model/BleedingedgeModel.php
@@ -22,6 +22,7 @@ use Joomla\Filesystem\Folder;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
+use Joomla\Database\ParameterType;
 
 #[\AllowDynamicProperties]
 class BleedingedgeModel extends BaseDatabaseModel
@@ -103,7 +104,7 @@ class BleedingedgeModel extends BaseDatabaseModel
 		}, $db->setQuery($query)->loadAssocList('id') ?: []);
 
 		// Releases pointing to non-existent folders will be deleted
-		$toDelete = array_filter($releases, function (ReleaseTable $release) use (&$known_folders) {
+		$toDelete = array_filter($releases, function (ReleaseTable $release) use (&$known_folders, $db) {
 			// Already unpublished releases will be automatically deleted
 			if (!$release->published)
 			{
@@ -134,10 +135,28 @@ class BleedingedgeModel extends BaseDatabaseModel
 				return true;
 			}
 
-			// The folder exists. Add it to the known folders array and check the files of this BE release.
+			// The folder exists. Add it to the known folders array.
 			$known_folders[] = $folderName;
 
-			$this->checkFiles($release);
+			// Only run checkFiles() when the release folder has been modified since our last scan.
+			$releaseFolderMtime = @filemtime($folder) ?: 0;
+			$lastKnownMtime     = (int) ($release->folder_mtime ?? 0);
+
+			if ($releaseFolderMtime !== $lastKnownMtime)
+			{
+				$this->checkFiles($release);
+
+				// Record the observed mtime via a targeted UPDATE so that modified/modified_by are not touched.
+				$releaseId = $release->id;
+				$db->setQuery(
+					(method_exists($db, 'createQuery') ? $db->createQuery() : $db->getQuery(true))
+						->update($db->quoteName('#__ars_releases'))
+						->set($db->quoteName('folder_mtime') . ' = :mtime')
+						->where($db->quoteName('id') . ' = :relid')
+						->bind(':mtime', $releaseFolderMtime, ParameterType::INTEGER)
+						->bind(':relid', $releaseId, ParameterType::INTEGER)
+				)->execute();
+			}
 
 			return false;
 		});
@@ -200,6 +219,17 @@ class BleedingedgeModel extends BaseDatabaseModel
 			$this->recursiveDeleteRelease($release);
 		}
 
+		// Only scan for new folders when the category directory itself has changed since the last scan.
+		// filemtime() on a directory advances whenever a subfolder is added or removed.
+		$categoryFolderMtime = @filemtime($this->folder) ?: 0;
+		$lastKnownCatMtime   = (int) ($this->category->last_scan ?? 0);
+
+		if ($categoryFolderMtime <= $lastKnownCatMtime)
+		{
+			// Category directory unchanged — no new folders can exist; skip the expensive scan.
+			return;
+		}
+
 		// Sort releases in ascending order
 		usort($releases, function (ReleaseTable $a, ReleaseTable $b) {
 			return $a->getId() <=> $b->getId();
@@ -244,7 +274,16 @@ class BleedingedgeModel extends BaseDatabaseModel
 		{
 			foreach ($allFolders as $folder)
 			{
-				if (!in_array($folder, $known_folders))
+				if (in_array($folder, $known_folders))
+				{
+					continue;
+				}
+
+				// Process the new folder atomically: if an error occurs mid-way (e.g. PHP timeout),
+				// the transaction rolls back and we don't leave a published release with zero items.
+				$db->transactionStart();
+
+				try
 				{
 					// Create a new entry
 					$notes         = '';
@@ -320,20 +359,32 @@ class BleedingedgeModel extends BaseDatabaseModel
 						}
 					}
 
-					// -- Create the BE release
-					try
-					{
-						/** @var ReleaseTable $table */
-						$table = $this->getMVCFactory()->createTable('Release');
-						$table->save($data);
-						$this->checkFiles($table);
-					}
-					catch (Exception $e)
-					{
-					}
+					// -- Create the BE release and its items
+					/** @var ReleaseTable $table */
+					$table = $this->getMVCFactory()->createTable('Release');
+					$table->save($data);
+					$this->checkFiles($table);
+
+					$db->transactionCommit();
+				}
+				catch (Exception $e)
+				{
+					$db->transactionRollback();
 				}
 			}
 		}
+
+		// Record the category folder mtime we just successfully processed.
+		// Any subsequent request that sees the same mtime will skip the new-folder block entirely.
+		$catId = $this->category_id;
+		$db->setQuery(
+			(method_exists($db, 'createQuery') ? $db->createQuery() : $db->getQuery(true))
+				->update($db->quoteName('#__ars_categories'))
+				->set($db->quoteName('last_scan') . ' = :mtime')
+				->where($db->quoteName('id') . ' = :catid')
+				->bind(':mtime', $categoryFolderMtime, ParameterType::INTEGER)
+				->bind(':catid', $catId, ParameterType::INTEGER)
+		)->execute();
 	}
 
 	public function checkFiles(ReleaseTable $release): void
@@ -410,11 +461,16 @@ class BleedingedgeModel extends BaseDatabaseModel
 			}
 		}
 
-		// Get the items
+		// Get the items — only the columns needed for the file sync logic.
 		$db         = $this->getDatabase();
 		$release_id = $release->id;
 		$query      = (method_exists($db, 'createQuery') ? $db->createQuery() : $db->getQuery(true))
-			->select('*')
+			->select([
+				$db->quoteName('id'),
+				$db->quoteName('release_id'),
+				$db->quoteName('filename'),
+				$db->quoteName('published'),
+			])
 			->from($db->quoteName('#__ars_items'))
 			->where($db->quoteName('release_id') . ' = :relid')
 			->bind(':relid', $release_id);


### PR DESCRIPTION
Fixes #244.

> **Note:** This pull request was created by an AI code assistant (Claude, by Anthropic) acting on instructions from the repository owner. The analysis, plan, and implementation were reviewed and approved by a human before submission.

## Problem

`BleedingedgeModel::scanCategory()` is called unconditionally in `ReleasesController::onBeforeDisplay()` on every HTTP request — including those served from Joomla's output cache, because `onBeforeDisplay()` fires before the cache check. For a category with N releases and M files per release, this performs O(N × M) filesystem and database operations on every page view:

- 1 DB query for all releases
- For each existing release: up to 6 `is_dir()` calls + 1 `Folder::files()` + 1 DB query for items + potential DB writes
- 1 `Folder::folders()` scan for new folders
- For each new folder (CI build): CHANGELOG read, plugin events, DB INSERT, `checkFiles()` (N item INSERTs + `reorder()`)

The "sometimes" nature is because the read-only path is merely slow, while new CI builds trigger the full write path synchronously inside the user's HTTP request. Under concurrent traffic, multiple requests race to process the same new folders.

An additional bug: no DB transaction wraps the release INSERT + item INSERTs, so a PHP timeout mid-scan leaves an orphan `published=1` release row with zero downloadable items.

## Solution

### DB-backed folder mtime tracking

Two new `INT UNSIGNED NULL` columns store the last-observed `filemtime()` Unix timestamp:

| Table | Column | Meaning |
|---|---|---|
| `#__ars_categories` | `last_scan` | `filemtime($categoryFolder)` at last scan |
| `#__ars_releases` | `folder_mtime` | `filemtime($releaseFolder)` at last `checkFiles()` run |

Using INT (Unix timestamp) avoids timezone conversion. `_supportNullValue = false` in both Table classes means normal admin saves leave these columns untouched.

Both values are written via targeted `UPDATE` queries (not `Table::store()`) so `modified`/`modified_by` are not disturbed.

### Changes

- **`BleedingedgeModel::scanCategory()`**: Skip `checkFiles()` for each release whose folder mtime matches the stored value. Skip the entire new-folder detection block when the category directory mtime is unchanged.
- **`BleedingedgeModel::checkFiles()`**: Change `SELECT *` on `#__ars_items` to project only the 4 needed columns (`id`, `release_id`, `filename`, `published`), avoiding transfer of `description (MEDIUMTEXT)` on every scan.
- **Transaction**: Each new-folder block (release INSERT + item INSERTs via `checkFiles()`) is wrapped in a `transactionStart/Commit/Rollback`, preventing orphan records on timeout.
- **`reorder()` preserved**: Items are displayed with `ORDER BY i.ordering ASC`; removing `reorder()` would leave all new items at `ordering=0` with non-deterministic display order.
- **Migration files**: `7.4.4.sql` for both MySQL and PostgreSQL.

### Performance impact

| Scenario | Before | After |
|---|---|---|
| No new files anywhere | N×(6 `is_dir` + `Folder::files` + DB query) per request | N×(1 `filemtime`) per request |
| New file in one release | Same + `checkFiles()` for all N releases | `checkFiles()` for that one release only |
| New folder (CI build) | Full inline processing | Same (unavoidable on first request after drop) |
| Cached page view | Full scan still runs | Scan runs but costs ~O(N) `filemtime()` calls |

## Files changed

| File | Change |
|---|---|
| `component/frontend/src/Model/BleedingedgeModel.php` | mtime short-circuits, transaction wrapper, SELECT projection |
| `component/backend/sql/install.mysql.utf8.sql` | Add 2 columns to CREATE TABLE |
| `component/backend/sql/install.postgresql.utf8.sql` | Same for PostgreSQL |
| `component/backend/sql/updates/mysql/7.4.4.sql` | New: ALTER TABLE migration |
| `component/backend/sql/updates/postgresql/7.4.4.sql` | New: ALTER TABLE migration |

## Not in scope (future work)

- Moving the scan to a `com_scheduler` task plugin — the correct long-term fix; zero sync scan per page view
- Adding `UNIQUE(category_id, alias)` to `#__ars_releases` — safe to add only after a de-dup check on existing data
- Batching N+1 items queries into a single `IN(release_ids)` query

## Test plan

- [ ] Run the Joomla updater on an existing install; confirm `last_scan` and `folder_mtime` columns appear as NULL
- [ ] First page load: all releases scan (NULL mtime), columns get populated
- [ ] Second page load with no file changes: scan completes near-instantly (no `checkFiles()` calls)
- [ ] Drop a new file into an existing release folder: only that release's `checkFiles()` runs
- [ ] Drop a new folder into the category directory: new release + items created atomically
- [ ] Confirm item display order is preserved (filesystem-alphabetical via `reorder()`)
- [ ] Verify REST API endpoints (`api.http`) are unaffected